### PR TITLE
Add scheduled mutation testing via the shared workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,13 @@ jobs:
             !**/dist/**
       - name: Lint
         run: make lint
+      - name: Setup uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          python-version: '3.13'
+          enable-cache: true
+      - name: Workflow contract tests
+        run: make test-workflow-contracts
       - name: Test and Measure Coverage
         uses: leynos/shared-actions/.github/actions/generate-coverage@aebb3f5b831102e2a10ef909c83d7d50ea86c332
         with:

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -1,0 +1,38 @@
+name: Mutation testing
+
+# Thin caller of the shared mutation-testing reusable workflow; caller
+# guide: leynos/shared-actions docs/mutation-cargo-workflow.md.
+# Scheduled runs mutate only files changed within the detection window;
+# manual dispatch runs mutate everything, fanned out across shards. To
+# test a branch, select it in the Actions "Run workflow" control.
+
+on:
+  schedule:
+    - cron: "20 10 * * *" # Daily, 10:20 UTC
+  workflow_dispatch:
+
+# Default the token to no scopes; the job opts in explicitly.
+permissions: {}
+
+# Serialize runs per ref: a dispatch during a scheduled run (or vice
+# versa) queues rather than racing. Runs are informational, so queued
+# runs wait instead of cancelling.
+concurrency:
+  group: mutation-testing-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  mutation:
+    permissions:
+      contents: read
+      id-token: write # OIDC workflow-source resolution
+    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@859416a90eb3987b46a57682c5d6b8964ad3f0a6
+    with:
+      # src/test_support.rs is test scaffolding compiled into the
+      # library unconditionally (unlike the #[cfg(test)]-gated
+      # test_helpers and tests modules, which cargo-mutants skips);
+      # its survivors are noise.
+      exclude-globs: "src/test_support.rs"
+      # Match the CI baseline (`make test` runs --all-features) so the
+      # test-backdoors feature-gated tests run against mutants.
+      extra-args: "--all-features"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
 **/*.rs.bk
+__pycache__/
 .memdb/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help all clean test build release lint fmt check-fmt markdownlint nixie typecheck scaleway-test scaleway-janitor
+.PHONY: help all clean test build release lint fmt check-fmt markdownlint nixie typecheck scaleway-test scaleway-janitor test-workflow-contracts
 
 
 TARGET ?= mriya
@@ -22,6 +22,9 @@ clean: ## Remove build artifacts
 
 test: ## Run tests with warnings treated as errors
 	RUSTFLAGS="$(RUST_FLAGS)" $(CARGO) test $(TEST_FLAGS) $(BUILD_JOBS)
+
+test-workflow-contracts: ## Validate the mutation-testing caller contract
+	uv run --with 'pytest>=8' --with 'pyyaml>=6' pytest tests/workflow_contracts -q
 
 scaleway-janitor: ## Delete test-run Scaleway resources (requires MRIYA_TEST_RUN_ID)
 	$(CARGO) run --bin mriya-janitor

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -1,0 +1,141 @@
+"""Contract tests for the mutation-testing caller workflow.
+
+The executable logic lives in the ``leynos/shared-actions`` reusable
+workflow, which carries its own unit and integration tests; mriya's
+caller is declarative configuration. These tests parse the caller with
+PyYAML and pin the contract it must uphold, so drift (repointing the pin
+at a branch, widening permissions, or losing the exclude and feature
+configuration) fails CI on the pull request rather than surfacing in a
+scheduled or manual run.
+
+Run via ``make test-workflow-contracts``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[2] / ".github" / "workflows" / "mutation-testing.yml"
+)
+
+#: The leynos/shared-actions commit the caller pins. Bump the workflow
+#: and this constant together.
+PINNED_SHA = "859416a90eb3987b46a57682c5d6b8964ad3f0a6"
+
+EXPECTED_USES = (
+    "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA
+)
+
+#: The exact caller configuration: exclude the unconditionally compiled
+#: test scaffolding and mirror the CI baseline's --all-features.
+EXPECTED_WITH = {
+    "exclude-globs": "src/test_support.rs",
+    "extra-args": "--all-features",
+}
+
+
+def _load() -> dict[str, object]:
+    """Parse the workflow file."""
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def _triggers(workflow: dict[str, object]) -> dict[str, object]:
+    """Return the ``on:`` mapping (PyYAML parses the bare key as True)."""
+    triggers = workflow.get("on", workflow.get(True))
+    assert isinstance(triggers, dict), "the workflow must declare an on: mapping"
+    return triggers
+
+
+def _mutation_job(workflow: dict[str, object]) -> dict[str, object]:
+    """Return the single calling job."""
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict), "the workflow must declare a jobs mapping"
+    assert jobs, "the workflow must declare at least one job"
+    assert list(jobs) == ["mutation"], (
+        f"expected a single job named 'mutation', found {sorted(jobs)}"
+    )
+    return jobs["mutation"]
+
+
+def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
+    """The job must call the shared workflow at the exact documented SHA."""
+    uses = _mutation_job(_load()).get("uses")
+    assert uses is not None, "jobs.mutation.uses is missing"
+    path, _, ref = uses.partition("@")
+    assert path == "leynos/shared-actions/.github/workflows/mutation-cargo.yml", (
+        f"jobs.mutation.uses must reference mutation-cargo.yml, got {path!r}"
+    )
+    assert len(ref) == 40, (
+        f"jobs.mutation.uses must pin a full 40-character commit SHA, "
+        f"not a branch or tag: {ref!r}"
+    )
+    assert all(c in "0123456789abcdef" for c in ref), (
+        f"jobs.mutation.uses must pin a lowercase hex commit SHA, "
+        f"not a branch or tag: {ref!r}"
+    )
+    assert uses == EXPECTED_USES, (
+        f"jobs.mutation.uses pins {ref!r}; this test documents {PINNED_SHA!r} — "
+        "bump the workflow and this test together"
+    )
+
+
+def test_job_permissions_are_exactly_least_privilege() -> None:
+    """The job grants contents: read and id-token: write, nothing broader."""
+    permissions = _mutation_job(_load()).get("permissions")
+    assert permissions == {"contents": "read", "id-token": "write"}, (
+        "jobs.mutation.permissions must be exactly "
+        f"{{'contents': 'read', 'id-token': 'write'}}, got {permissions!r}"
+    )
+
+
+def test_workflow_default_permissions_are_empty() -> None:
+    """The workflow-level default token scope is empty."""
+    workflow = _load()
+    assert workflow.get("permissions") == {}, (
+        f"top-level permissions must be an empty mapping, got "
+        f"{workflow.get('permissions')!r}"
+    )
+
+
+def test_concurrency_serializes_per_ref_without_cancelling() -> None:
+    """Runs queue per ref instead of cancelling one another."""
+    concurrency = _load().get("concurrency")
+    assert isinstance(concurrency, dict), "the workflow must declare concurrency"
+    assert concurrency.get("group") == "mutation-testing-${{ github.ref }}", (
+        f"concurrency.group must key on the triggering ref, got "
+        f"{concurrency.get('group')!r}"
+    )
+    assert concurrency.get("cancel-in-progress") is False, (
+        f"concurrency.cancel-in-progress must be false, got "
+        f"{concurrency.get('cancel-in-progress')!r}"
+    )
+
+
+def test_triggers_keep_schedule_and_plain_dispatch() -> None:
+    """The daily schedule stays; dispatch has no legacy branch input."""
+    triggers = _triggers(_load())
+    schedule = triggers.get("schedule")
+    assert schedule == [{"cron": "20 10 * * *"}], (
+        f"on.schedule must be the daily 10:20 UTC cron, got {schedule!r}"
+    )
+    assert "workflow_dispatch" in triggers, "on.workflow_dispatch is missing"
+    dispatch = triggers.get("workflow_dispatch") or {}
+    inputs = dispatch.get("inputs") or {}
+    assert "branch" not in inputs, (
+        "on.workflow_dispatch must not declare a branch input; the Actions "
+        "run-workflow control selects the ref"
+    )
+
+
+def test_with_block_carries_the_caller_configuration() -> None:
+    """The caller passes exactly the documented excludes and feature args."""
+    with_block = _mutation_job(_load()).get("with")
+    assert isinstance(with_block, dict), "jobs.mutation.with is missing"
+    assert with_block == EXPECTED_WITH, (
+        f"jobs.mutation.with must be exactly {EXPECTED_WITH!r} "
+        f"(scaffolding exclude plus the CI --all-features baseline), "
+        f"got {with_block!r}"
+    )


### PR DESCRIPTION
## Summary

Enrols mriya in the estate-wide mutation-testing rollout. This pull request adds a thin caller of the [leynos/shared-actions](https://github.com/leynos/shared-actions) `mutation-cargo.yml` reusable workflow, pinned to commit `859416a90eb3987b46a57682c5d6b8964ad3f0a6`, scheduled daily at 10:20 UTC (`20 10 * * *`) with `workflow_dispatch` for manual sharded runs. Runs are informational only: a daily guard mutates recently changed files, and manual dispatch fans the full crate out across shards.

## Configuration for this repository

- [`.github/workflows/mutation-testing.yml`](https://github.com/leynos/mriya/blob/add-mutation-testing/.github/workflows/mutation-testing.yml) — the caller. mriya is a single-crate package with all mutable Rust source under `src/`, so the default `paths` suffice and no `extra-crate-dirs` or `--test-workspace` flag is needed.
  - `exclude-globs: "src/test_support.rs"` — test scaffolding compiled into the library unconditionally (`pub mod test_support;`). The `test_helpers`, `main_tests`, and per-module `tests` modules are all `#[cfg(test)]`-gated, which cargo-mutants skips on its own, so they need no exclusion.
  - `extra-args: "--all-features"` — mirrors the CI baseline (`make test` runs `cargo test --all-targets --all-features`) so the `test-backdoors` feature-gated tests run against mutants.
- [`tests/workflow_contracts/mutation_testing_test.py`](https://github.com/leynos/mriya/blob/add-mutation-testing/tests/workflow_contracts/mutation_testing_test.py) — contract tests pinning the SHA, least-privilege permissions, concurrency, triggers, and the exact `with:` block, so drift fails CI on the pull request rather than in a scheduled run.
- [`Makefile`](https://github.com/leynos/mriya/blob/add-mutation-testing/Makefile) — new `test-workflow-contracts` target running the suite via `uv run` with pytest and PyYAML.
- [`.github/workflows/ci.yml`](https://github.com/leynos/mriya/blob/add-mutation-testing/.github/workflows/ci.yml) — the `build-test` job gains a pinned `astral-sh/setup-uv` step and a `Workflow contract tests` step after Lint.
- [`.gitignore`](https://github.com/leynos/mriya/blob/add-mutation-testing/.gitignore) — ignores `__pycache__/`.

## Validation

- Both workflow files parse with PyYAML and pass actionlint.
- `make test-workflow-contracts`: 6 passed, including a negative test (pin temporarily changed to `@v1`; the SHA assertion failed as designed, then restored to green).
- Baseline verification: plain `cargo test --all-features` (the invocation cargo-mutants uses, not nextest) passes locally — 153 tests, 0 failures — so the mutation baseline is unblocked.

## References

- Caller guide: <https://github.com/leynos/shared-actions/blob/main/docs/mutation-cargo-workflow.md>
- Estate template: leynos/wireframe#572
