### PR TITLE
Adopt the Whitaker Dylint suite in the lint gate and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       BUILD_PROFILE: debug
+      WHITAKER_INSTALLER_VERSION: '0.2.5'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: Setup Rust
@@ -26,6 +27,24 @@ jobs:
             **/*.md
             !**/target/**
             !**/dist/**
+      - name: Cache Whitaker installer
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+        with:
+          path: |
+            ~/.cargo/bin/whitaker-installer
+            ~/.cache/cargo-binstall
+          key: whitaker-installer-${{ runner.os }}-${{ runner.arch }}-${{ env.WHITAKER_INSTALLER_VERSION }}
+      - name: Install Whitaker Dylint suite
+        run: |
+          if ! command -v whitaker-installer >/dev/null 2>&1; then
+            if cargo binstall --version >/dev/null 2>&1; then
+              cargo binstall --no-confirm --locked "whitaker-installer@${WHITAKER_INSTALLER_VERSION}"
+            else
+              echo "cargo-binstall unavailable; building whitaker-installer from crates.io"
+              cargo install --locked whitaker-installer --version "${WHITAKER_INSTALLER_VERSION}"
+            fi
+          fi
+          whitaker-installer
       - name: Lint
         run: make lint
       - name: Test and Measure Coverage

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
 name = "arc-swap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1410,6 +1416,7 @@ dependencies = [
 name = "mriya"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "assert_cmd",
  "camino",
  "cap-std 4.0.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ camino = "1.1"
 cap-std = { version = "4.0.2", features = ["fs_utf8"] }
 
 [dev-dependencies]
+anyhow = "1.0"
 rstest = "0.22"
 rstest-bdd = "0.2.0"
 rstest-bdd-macros = "0.2.0"

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ CLIPPY_FLAGS ?= $(CARGO_FLAGS) -- $(RUST_FLAGS)
 TEST_FLAGS ?= $(CARGO_FLAGS)
 MDLINT ?= markdownlint-cli2
 NIXIE ?= nixie
+WHITAKER ?= whitaker
 
 build: target/debug/$(TARGET) ## Build debug binary
 release: target/release/$(TARGET) ## Build release binary
@@ -41,9 +42,10 @@ typecheck: ## Typecheck the workspace
 target/%/$(TARGET): ## Build binary in debug or release mode
 	$(CARGO) build $(BUILD_JOBS) $(if $(findstring release,$(@)),--release) --bin $(TARGET)
 
-lint: ## Run Clippy with warnings denied
+lint: ## Run Clippy and the Whitaker Dylint suite with warnings denied
 	RUSTDOCFLAGS="$(RUSTDOC_FLAGS)" $(CARGO) doc --no-deps
 	$(CARGO) clippy $(CLIPPY_FLAGS)
+	RUSTFLAGS="$(RUST_FLAGS)" $(WHITAKER) --all -- $(CARGO_FLAGS)
 
 fmt: ## Format Rust and Markdown sources
 	$(CARGO) fmt --all

--- a/src/config_store/tests.rs
+++ b/src/config_store/tests.rs
@@ -6,9 +6,11 @@
 //! invalid TOML and missing parent directories. Temporary directories and
 //! fixtures keep each case isolated from repo configuration.
 
-use super::*;
+use anyhow::{Context as _, bail, ensure};
 use rstest::{fixture, rstest};
 use tempfile::TempDir;
+
+use super::*;
 
 struct ConfigFixture {
     _tmp: TempDir,
@@ -17,129 +19,160 @@ struct ConfigFixture {
 }
 
 #[fixture]
-fn config_fixture() -> ConfigFixture {
-    let tmp = TempDir::new().expect("failed to create tempdir");
-    let path = temp_config_path(&tmp);
-    let store = ConfigStore::with_discovery(discovery_for_path(&path));
-    ConfigFixture {
+fn config_fixture() -> anyhow::Result<ConfigFixture> {
+    let tmp = TempDir::new().context("failed to create tempdir")?;
+    let path = temp_config_path(&tmp)?;
+    let store = ConfigStore::with_discovery(discovery_for_path(&path)?);
+    Ok(ConfigFixture {
         _tmp: tmp,
         path,
         store,
-    }
+    })
 }
 
-fn discovery_for_path(path: &Utf8Path) -> ConfigDiscovery {
+fn discovery_for_path(path: &Utf8Path) -> anyhow::Result<ConfigDiscovery> {
     let root = path
         .parent()
-        .expect("temp path should have a parent directory");
-    ConfigDiscovery::builder(APP_NAME)
+        .context("temp path should have a parent directory")?;
+    Ok(ConfigDiscovery::builder(APP_NAME)
         .env_var(CONFIG_ENV_VAR)
         .config_file_name(CONFIG_FILE_NAME)
         .dotfile_name(DOTFILE_NAME)
         .project_file_name(PROJECT_FILE_NAME)
         .clear_project_roots()
         .add_project_root(root)
-        .build()
+        .build())
 }
 
-fn temp_config_path(tmp: &TempDir) -> Utf8PathBuf {
-    Utf8PathBuf::from_path_buf(tmp.path().join("mriya.toml")).expect("temp path should be utf8")
+fn temp_config_path(tmp: &TempDir) -> anyhow::Result<Utf8PathBuf> {
+    Utf8PathBuf::from_path_buf(tmp.path().join("mriya.toml"))
+        .map_err(|path| anyhow::anyhow!("temp path should be utf8: {}", path.display()))
 }
 
 #[rstest]
-fn write_volume_id_creates_config_file(config_fixture: ConfigFixture) {
-    let ConfigFixture { path, store, .. } = config_fixture;
+fn write_volume_id_creates_config_file(
+    config_fixture: anyhow::Result<ConfigFixture>,
+) -> anyhow::Result<()> {
+    let ConfigFixture { path, store, .. } = config_fixture?;
 
     let written_path = store
         .write_volume_id("vol-123", true)
-        .expect("write volume id should succeed");
+        .context("write volume id should succeed")?;
 
-    assert_eq!(written_path, path);
-    let contents = read_config(&path).expect("read config should succeed");
-    let value = parse_toml(&path, &contents).expect("parse config should succeed");
-    let volume_id = read_volume_id(&path, &value).expect("extract volume id should succeed");
-    assert_eq!(volume_id, Some(String::from("vol-123")));
+    ensure!(written_path == path, "written path should match fixture");
+    let contents = read_config(&path).context("read config should succeed")?;
+    let value = parse_toml(&path, &contents).context("parse config should succeed")?;
+    let volume_id = read_volume_id(&path, &value).context("extract volume id should succeed")?;
+    ensure!(
+        volume_id == Some(String::from("vol-123")),
+        "volume id should round-trip"
+    );
+    Ok(())
 }
 
 #[rstest]
-fn write_volume_id_rejects_existing_without_force(config_fixture: ConfigFixture) {
-    config_fixture
+fn write_volume_id_rejects_existing_without_force(
+    config_fixture: anyhow::Result<ConfigFixture>,
+) -> anyhow::Result<()> {
+    let fixture = config_fixture?;
+    fixture
         .store
         .write_volume_id("vol-123", true)
-        .expect("seed config should succeed");
+        .context("seed config should succeed")?;
 
-    let Err(err) = config_fixture.store.write_volume_id("vol-456", false) else {
-        panic!("overwrite should fail without force");
+    let Err(err) = fixture.store.write_volume_id("vol-456", false) else {
+        bail!("overwrite should fail without force");
     };
 
     let ConfigStoreError::VolumeAlreadyConfigured { volume_id } = err else {
-        panic!("expected VolumeAlreadyConfigured error");
+        bail!("expected VolumeAlreadyConfigured error");
     };
-    assert_eq!(volume_id, "vol-123");
+    ensure!(volume_id == "vol-123", "error should report existing id");
+    Ok(())
 }
 
 #[rstest]
-fn write_volume_id_overwrites_when_forced(config_fixture: ConfigFixture) {
-    config_fixture
+fn write_volume_id_overwrites_when_forced(
+    config_fixture: anyhow::Result<ConfigFixture>,
+) -> anyhow::Result<()> {
+    let fixture = config_fixture?;
+    fixture
         .store
         .write_volume_id("vol-123", true)
-        .expect("seed config should succeed");
+        .context("seed config should succeed")?;
 
-    config_fixture
+    fixture
         .store
         .write_volume_id("vol-456", true)
-        .expect("overwrite config should succeed");
+        .context("overwrite config should succeed")?;
 
-    let contents = read_config(&config_fixture.path).expect("read config should succeed");
-    let value = parse_toml(&config_fixture.path, &contents).expect("parse config should succeed");
+    let contents = read_config(&fixture.path).context("read config should succeed")?;
+    let value = parse_toml(&fixture.path, &contents).context("parse config should succeed")?;
     let volume_id =
-        read_volume_id(&config_fixture.path, &value).expect("extract volume id should succeed");
-    assert_eq!(volume_id, Some(String::from("vol-456")));
+        read_volume_id(&fixture.path, &value).context("extract volume id should succeed")?;
+    ensure!(
+        volume_id == Some(String::from("vol-456")),
+        "forced overwrite should replace the volume id"
+    );
+    Ok(())
 }
 
 #[rstest]
 #[case("not = [")]
 #[case("scaleway =")]
-fn parse_toml_rejects_invalid_content(config_fixture: ConfigFixture, #[case] contents: &str) {
-    let Err(err) = parse_toml(&config_fixture.path, contents) else {
-        panic!("parse should fail");
+fn parse_toml_rejects_invalid_content(
+    config_fixture: anyhow::Result<ConfigFixture>,
+    #[case] contents: &str,
+) -> anyhow::Result<()> {
+    let fixture = config_fixture?;
+    let Err(err) = parse_toml(&fixture.path, contents) else {
+        bail!("parse should fail");
     };
     let ConfigStoreError::Parse { path, .. } = err else {
-        panic!("expected parse error");
+        bail!("expected parse error");
     };
-    assert_eq!(path, config_fixture.path);
+    ensure!(path == fixture.path, "error should cite the config path");
+    Ok(())
 }
 
 #[rstest]
-fn read_config_reports_missing_parent_dir(config_fixture: ConfigFixture) {
-    let parent = config_fixture
+fn read_config_reports_missing_parent_dir(
+    config_fixture: anyhow::Result<ConfigFixture>,
+) -> anyhow::Result<()> {
+    let fixture = config_fixture?;
+    let parent = fixture
         .path
         .parent()
-        .expect("config path should have a parent directory");
+        .context("config path should have a parent directory")?;
     let missing_path = parent.join("missing").join("nested").join("mriya.toml");
 
     let Err(err) = read_config(&missing_path) else {
-        panic!("read should fail");
+        bail!("read should fail");
     };
     let ConfigStoreError::Io { path, .. } = err else {
-        panic!("expected io error");
+        bail!("expected io error");
     };
-    assert_eq!(
-        path,
-        missing_path
-            .parent()
-            .expect("missing path should have a parent directory")
-            .to_path_buf()
+    let missing_parent = missing_path
+        .parent()
+        .context("missing path should have a parent directory")?;
+    ensure!(
+        path == missing_parent.to_path_buf(),
+        "error should cite the missing parent directory"
     );
+    Ok(())
 }
 
 #[rstest]
-fn read_volume_id_rejects_non_table_root(config_fixture: ConfigFixture) {
-    let Err(err) = read_volume_id(&config_fixture.path, &toml::Value::String("nope".into())) else {
-        panic!("read should fail");
+fn read_volume_id_rejects_non_table_root(
+    config_fixture: anyhow::Result<ConfigFixture>,
+) -> anyhow::Result<()> {
+    let fixture = config_fixture?;
+    let Err(err) = read_volume_id(&fixture.path, &toml::Value::String("nope".into())) else {
+        bail!("read should fail");
     };
     let ConfigStoreError::InvalidStructure { path, .. } = err else {
-        panic!("expected invalid structure error");
+        bail!("expected invalid structure error");
     };
-    assert_eq!(path, config_fixture.path);
+    ensure!(path == fixture.path, "error should cite the config path");
+    Ok(())
 }

--- a/src/init/helpers.rs
+++ b/src/init/helpers.rs
@@ -40,6 +40,7 @@ pub(super) fn slugify(value: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    //! Unit tests for init helper functions.
     use super::*;
     use rstest::rstest;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,19 +56,34 @@ enum CliError {
     Init(#[from] InitError<ScalewayBackendError>),
 }
 
-#[tokio::main]
-async fn main() {
+fn main() {
+    // Build the runtime explicitly so runtime construction errors are
+    // reported through the usual error path instead of panicking inside the
+    // `#[tokio::main]` expansion.
+    let exit_code = match tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(runtime) => runtime.block_on(async_main()),
+        Err(err) => {
+            writeln!(io::stderr(), "failed to start async runtime: {err}").ok();
+            1
+        }
+    };
+
+    process::exit(exit_code);
+}
+
+async fn async_main() -> i32 {
     let cli = Cli::parse();
-    let exit_code = match cli {
+    match cli {
         Cli::Run(command) => exec_run(command).await,
         Cli::Init(command) => exec_init(command).await,
     }
     .unwrap_or_else(|err| {
         report_error(&err);
         1
-    });
-
-    process::exit(exit_code);
+    })
 }
 
 async fn exec_run(command: RunCommand) -> Result<i32, CliError> {

--- a/src/scaleway/mod.rs
+++ b/src/scaleway/mod.rs
@@ -225,6 +225,7 @@ impl VolumeBackend for ScalewayBackend {
 
 #[cfg(test)]
 mod tests {
+    //! Unit tests for Scaleway backend tagging.
     use super::ScalewayBackend;
 
     #[test]

--- a/src/scaleway/volume.rs
+++ b/src/scaleway/volume.rs
@@ -23,6 +23,7 @@ pub(crate) struct UpdateInstanceVolumesRequest {
 
 #[cfg(test)]
 mod tests {
+    //! Unit tests for volume attachment serialisation.
     use super::*;
 
     #[test]

--- a/src/sync/types.rs
+++ b/src/sync/types.rs
@@ -138,6 +138,24 @@ fn forward_stream(
     })
 }
 
+/// Join a forwarder thread, mapping panics and stream errors to
+/// [`SyncError::Spawn`].
+///
+/// Returns an empty string when no forwarder was spawned for the stream.
+fn join_forwarder(
+    handle: Option<thread::JoinHandle<Result<String, SyncError>>>,
+    program: &str,
+    stream_name: &str,
+) -> Result<String, SyncError> {
+    match handle {
+        Some(join_handle) => join_handle.join().map_err(|_| SyncError::Spawn {
+            program: program.to_owned(),
+            message: format!("{stream_name} forwarder panicked"),
+        })?,
+        None => Ok(String::new()),
+    }
+}
+
 /// Command runner that streams subprocess stdout/stderr while capturing them.
 #[derive(Clone, Debug, Default)]
 pub struct StreamingCommandRunner;
@@ -168,21 +186,8 @@ impl CommandRunner for StreamingCommandRunner {
             message: err.to_string(),
         })?;
 
-        let stdout = match stdout_handle {
-            Some(handle) => handle.join().map_err(|_| SyncError::Spawn {
-                program: program.to_owned(),
-                message: String::from("stdout forwarder panicked"),
-            })??,
-            None => String::new(),
-        };
-
-        let stderr = match stderr_handle {
-            Some(handle) => handle.join().map_err(|_| SyncError::Spawn {
-                program: program.to_owned(),
-                message: String::from("stderr forwarder panicked"),
-            })??,
-            None => String::new(),
-        };
+        let stdout = join_forwarder(stdout_handle, program, "stdout")?;
+        let stderr = join_forwarder(stderr_handle, program, "stderr")?;
 
         Ok(CommandOutput {
             code: status.code(),

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -31,22 +31,23 @@ fn valid_config() -> ScalewayConfig {
 
 /// Helper to create a temporary cloud-init user-data file for testing.
 /// Returns the `TempDir` (must be kept alive) and the file path as a String.
-fn write_temp_cloud_init_file(filename: &str, content: &str) -> (TempDir, String) {
-    let tmp = TempDir::new().unwrap_or_else(|err| panic!("tempdir: {err}"));
+fn write_temp_cloud_init_file(filename: &str, content: &str) -> anyhow::Result<(TempDir, String)> {
+    use anyhow::Context as _;
+    let tmp = TempDir::new().context("tempdir")?;
     let path = tmp.path().join(filename);
     let tmp_root =
-        Utf8PathBuf::from_path_buf(tmp.path().to_path_buf()).unwrap_or_else(|non_utf8_path| {
-            panic!("temp dir should be utf8: {}", non_utf8_path.display());
-        });
+        Utf8PathBuf::from_path_buf(tmp.path().to_path_buf()).map_err(|non_utf8_path| {
+            anyhow::anyhow!("temp dir should be utf8: {}", non_utf8_path.display())
+        })?;
     Dir::open_ambient_dir(&tmp_root, ambient_authority())
-        .unwrap_or_else(|err| panic!("open temp dir: {err}"))
+        .context("open temp dir")?
         .write(filename, content)
-        .unwrap_or_else(|err| panic!("write file: {err}"));
+        .context("write file")?;
     let path_str = path
         .to_str()
-        .unwrap_or_else(|| panic!("temp path should be utf8: {}", path.display()))
+        .with_context(|| format!("temp path should be utf8: {}", path.display()))?
         .to_owned();
-    (tmp, path_str)
+    Ok((tmp, path_str))
 }
 
 #[test]
@@ -192,7 +193,8 @@ fn config_rejects_empty_cloud_init_inline() {
 
 #[test]
 fn config_reads_cloud_init_user_data_from_file() {
-    let (_tmp, path_str) = write_temp_cloud_init_file("user-data.txt", "file-user-data");
+    let (_tmp, path_str) = write_temp_cloud_init_file("user-data.txt", "file-user-data")
+        .unwrap_or_else(|err| panic!("create cloud-init file: {err}"));
 
     let cfg = ScalewayConfig {
         cloud_init_user_data_file: Some(path_str),
@@ -235,7 +237,8 @@ fn config_errors_when_cloud_init_user_data_file_missing() {
 
 #[test]
 fn config_errors_when_cloud_init_user_data_file_is_empty() {
-    let (_tmp, path_str) = write_temp_cloud_init_file("user-data-empty.txt", "   \n\t  ");
+    let (_tmp, path_str) = write_temp_cloud_init_file("user-data-empty.txt", "   \n\t  ")
+        .unwrap_or_else(|err| panic!("create cloud-init file: {err}"));
 
     let cfg = ScalewayConfig {
         cloud_init_user_data_file: Some(path_str),

--- a/tests/init/test_doubles.rs
+++ b/tests/init/test_doubles.rs
@@ -75,7 +75,7 @@ impl ScriptedVolumeBackend {
     pub fn fail_create_volume(&self) {
         self.state
             .lock()
-            .unwrap_or_else(|err| panic!("lock poisoned: fail_create_volume: {err}"))
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .failures
             .set(FailureMode::CreateVolume);
     }
@@ -83,7 +83,7 @@ impl ScriptedVolumeBackend {
     pub fn fail_provision(&self) {
         self.state
             .lock()
-            .unwrap_or_else(|err| panic!("lock poisoned: fail_provision: {err}"))
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .failures
             .set(FailureMode::Provision);
     }
@@ -91,7 +91,7 @@ impl ScriptedVolumeBackend {
     pub fn fail_wait(&self) {
         self.state
             .lock()
-            .unwrap_or_else(|err| panic!("lock poisoned: fail_wait: {err}"))
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .failures
             .set(FailureMode::Wait);
     }
@@ -99,7 +99,7 @@ impl ScriptedVolumeBackend {
     pub fn fail_detach(&self) {
         self.state
             .lock()
-            .unwrap_or_else(|err| panic!("lock poisoned: fail_detach: {err}"))
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .failures
             .set(FailureMode::Detach);
     }
@@ -107,7 +107,7 @@ impl ScriptedVolumeBackend {
     pub fn fail_destroy(&self) {
         self.state
             .lock()
-            .unwrap_or_else(|err| panic!("lock poisoned: fail_destroy: {err}"))
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .failures
             .set(FailureMode::Destroy);
     }
@@ -115,14 +115,14 @@ impl ScriptedVolumeBackend {
     pub fn create_volume_calls(&self) -> u32 {
         self.state
             .lock()
-            .unwrap_or_else(|err| panic!("lock poisoned: create_volume_calls: {err}"))
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .create_volume_calls
     }
 
     pub fn destroy_calls(&self) -> u32 {
         self.state
             .lock()
-            .unwrap_or_else(|err| panic!("lock poisoned: destroy_calls: {err}"))
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .destroy_calls
     }
 
@@ -295,7 +295,7 @@ impl MemoryConfigStore {
         store
             .state
             .lock()
-            .unwrap_or_else(|err| panic!("lock poisoned: with_existing: {err}"))
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .existing_volume_id = Some(volume_id.to_owned());
         store
     }
@@ -303,7 +303,7 @@ impl MemoryConfigStore {
     pub fn write_calls(&self) -> u32 {
         self.state
             .lock()
-            .unwrap_or_else(|err| panic!("lock poisoned: write_calls: {err}"))
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .write_calls
     }
 

--- a/tests/janitor/bdd_steps.rs
+++ b/tests/janitor/bdd_steps.rs
@@ -88,10 +88,9 @@ fn scw_lists_remaining_server(janitor_context: JanitorContext) -> JanitorContext
 
 #[when("I run the janitor sweep")]
 fn run_sweep(mut janitor_context: JanitorContext) -> JanitorContext {
-    let config = janitor_context
-        .config
-        .clone()
-        .unwrap_or_else(|| panic!("test setup requires configured janitor"));
+    let Some(config) = janitor_context.config.clone() else {
+        panic!("test setup requires configured janitor");
+    };
     let janitor = Janitor::new(config, janitor_context.runner.clone());
     janitor_context.outcome = Some(match janitor.sweep() {
         Ok(summary) => SweepOutcome::Success(summary),

--- a/tests/janitor/test_helpers.rs
+++ b/tests/janitor/test_helpers.rs
@@ -27,6 +27,8 @@ pub fn janitor_context() -> JanitorContext {
 }
 
 pub fn build_config(project: &str, run_id: &str) -> JanitorConfig {
-    JanitorConfig::new(project, run_id, DEFAULT_SCW_BIN)
-        .unwrap_or_else(|err| panic!("janitor config should be valid: {err}"))
+    match JanitorConfig::new(project, run_id, DEFAULT_SCW_BIN) {
+        Ok(config) => config,
+        Err(err) => panic!("janitor config should be valid: {err}"),
+    }
 }

--- a/tests/run/test_doubles.rs
+++ b/tests/run/test_doubles.rs
@@ -33,14 +33,14 @@ impl ScriptedBackend {
     pub fn fail_on_destroy(&self) {
         self.state
             .lock()
-            .unwrap_or_else(|err| panic!("scripted backend lock poisoned: fail_on_destroy: {err}"))
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .fail_on_destroy = true;
     }
 
     pub fn destroy_calls(&self) -> u32 {
         self.state
             .lock()
-            .unwrap_or_else(|err| panic!("scripted backend lock poisoned: destroy_calls: {err}"))
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .destroy_calls
     }
 }
@@ -86,7 +86,7 @@ impl Backend for ScriptedBackend {
             let mut state = self
                 .state
                 .lock()
-                .unwrap_or_else(|err| panic!("scripted backend lock poisoned in destroy: {err}"));
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             state.destroy_calls += 1;
             if state.fail_on_destroy {
                 return Err(ScriptedBackendError::Destroy);

--- a/tests/run/test_helpers.rs
+++ b/tests/run/test_helpers.rs
@@ -65,7 +65,10 @@ pub fn run_context_result() -> Result<RunContext, RunTestError> {
 
 #[fixture]
 pub fn run_context(run_context_result: Result<RunContext, RunTestError>) -> RunContext {
-    run_context_result.unwrap_or_else(|err| panic!("run context fixture should initialise: {err}"))
+    match run_context_result {
+        Ok(context) => context,
+        Err(err) => panic!("run context fixture should initialise: {err}"),
+    }
 }
 
 pub fn build_run_context() -> Result<RunContext, RunTestError> {
@@ -89,12 +92,15 @@ pub fn build_run_context() -> Result<RunContext, RunTestError> {
 }
 
 pub fn request() -> InstanceRequest {
-    InstanceRequestBuilder::new()
+    let built = InstanceRequestBuilder::new()
         .image_label("ubuntu")
         .instance_type(DEFAULT_INSTANCE_TYPE)
         .zone("fr-par-1")
         .project_id("project")
         .architecture("x86_64")
-        .build()
-        .unwrap_or_else(|err| panic!("builder fixture should be valid: {err}"))
+        .build();
+    match built {
+        Ok(request) => request,
+        Err(err) => panic!("builder fixture should be valid: {err}"),
+    }
 }

--- a/tests/scaleway_backend.rs
+++ b/tests/scaleway_backend.rs
@@ -12,16 +12,18 @@ use rstest_bdd::skip;
 use rstest_bdd_macros::{given, scenario, then, when};
 use tokio::runtime::Runtime;
 
-static RUNTIME: LazyLock<Runtime> = LazyLock::new(|| {
-    Runtime::new()
-        .unwrap_or_else(|err| panic!("tokio runtime should start for behavioural tests: {err}"))
-});
+static RUNTIME: LazyLock<Result<Runtime, std::io::Error>> = LazyLock::new(Runtime::new);
 
 fn block_on<Fut, T>(future: Fut) -> Result<T, ScalewayBackendError>
 where
     Fut: std::future::Future<Output = Result<T, ScalewayBackendError>>,
 {
-    RUNTIME.block_on(future)
+    match RUNTIME.as_ref() {
+        Ok(runtime) => runtime.block_on(future),
+        Err(err) => Err(ScalewayBackendError::Config(format!(
+            "tokio runtime should start for behavioural tests: {err}"
+        ))),
+    }
 }
 
 fn scaleway_integration_enabled() -> bool {

--- a/tests/scaleway_cloud_init.rs
+++ b/tests/scaleway_cloud_init.rs
@@ -14,10 +14,7 @@ use rstest_bdd_macros::{given, scenario, then, when};
 use tempfile::TempDir;
 use tokio::runtime::Runtime;
 
-static RUNTIME: LazyLock<Runtime> = LazyLock::new(|| {
-    Runtime::new()
-        .unwrap_or_else(|err| panic!("tokio runtime should start for integration tests: {err}"))
-});
+static RUNTIME: LazyLock<Result<Runtime, std::io::Error>> = LazyLock::new(Runtime::new);
 
 fn scaleway_integration_enabled() -> bool {
     let enabled = std::env::var("MRIYA_RUN_SCALEWAY_TESTS").unwrap_or_default();
@@ -72,9 +69,10 @@ fn syncer() -> Result<Syncer<ProcessCommandRunner>, String> {
 
 #[fixture]
 fn temp_source_dir() -> std::sync::Arc<TempDir> {
-    std::sync::Arc::new(
-        TempDir::new().unwrap_or_else(|err| panic!("temp dir should be created: {err}")),
-    )
+    match TempDir::new() {
+        Ok(dir) => std::sync::Arc::new(dir),
+        Err(err) => panic!("temp dir should be created: {err}"),
+    }
 }
 
 const CLOUD_INIT_JQ: &str = concat!(
@@ -119,7 +117,12 @@ fn provision_with_cloud_init_and_run(
     let orchestrator: RunOrchestrator<ScalewayBackend, ProcessCommandRunner> =
         RunOrchestrator::new(backend, sync_pipeline);
 
-    RUNTIME.block_on(async {
+    let runtime = RUNTIME.as_ref().map_err(|err| {
+        mriya::RunError::Provision(ScalewayBackendError::Provider {
+            message: format!("tokio runtime should start for integration tests: {err}"),
+        })
+    })?;
+    runtime.block_on(async {
         orchestrator
             .execute(&request, &source, command.as_str())
             .await

--- a/tests/sync/test_helpers.rs
+++ b/tests/sync/test_helpers.rs
@@ -143,7 +143,10 @@ pub fn workspace_result() -> Result<Workspace, SyncError> {
 
 #[fixture]
 pub fn workspace(workspace_result: Result<Workspace, SyncError>) -> Workspace {
-    workspace_result.unwrap_or_else(|err| panic!("workspace fixture should initialise: {err}"))
+    match workspace_result {
+        Ok(workspace) => workspace,
+        Err(err) => panic!("workspace fixture should initialise: {err}"),
+    }
 }
 
 #[fixture]
@@ -159,8 +162,10 @@ pub fn scripted_context_result() -> Result<ScriptedContext, SyncError> {
 pub fn scripted_context(
     scripted_context_result: Result<ScriptedContext, SyncError>,
 ) -> ScriptedContext {
-    scripted_context_result
-        .unwrap_or_else(|err| panic!("scripted context fixture should initialise: {err}"))
+    match scripted_context_result {
+        Ok(context) => context,
+        Err(err) => panic!("scripted context fixture should initialise: {err}"),
+    }
 }
 
 #[fixture]


### PR DESCRIPTION
## Summary

This pull request adopts the Whitaker Dylint suite as part of the estate-wide rollout (see leynos/netsuke#410 for the reference adoption). The `lint` Makefile target now runs the suite after Clippy with warnings denied, reusing the existing `RUST_FLAGS`/`CARGO_FLAGS` conventions, and CI installs the pinned `whitaker-installer` (0.2.5) before the lint step, preferring `cargo binstall` with a `cargo install --locked` fallback and caching the installer binary keyed on its version. The release dry-run workflow is deliberately untouched so its required status checks keep their exact job names.

Adopting the suite surfaced findings that are fixed in a preceding commit: `main` now builds its Tokio runtime explicitly so construction errors are reported rather than panicking inside the `#[tokio::main]` expansion; `StreamingCommandRunner::run` gained a `join_forwarder` helper to resolve `bumpy_road_function`; the configuration store tests use `anyhow::Result` fixtures with `ensure!`/`bail!` assertions; test doubles recover poisoned mutex guards with `PoisonError::into_inner`; and the remaining panicking `unwrap_or_else` fallbacks in test helpers were replaced with explicit `match`/`let-else` failures or error propagation. No `dylint.toml` exclusions were required.

## Review walkthrough

- [`Makefile`](https://github.com/leynos/mriya/blob/adopt-whitaker/Makefile) — `WHITAKER` tool variable and suite invocation in `lint`.
- [`.github/workflows/ci.yml`](https://github.com/leynos/mriya/blob/adopt-whitaker/.github/workflows/ci.yml) — installer cache and hardened install step ahead of the Lint step.
- [`src/main.rs`](https://github.com/leynos/mriya/blob/adopt-whitaker/src/main.rs) — explicit runtime construction and `async_main`.
- [`src/sync/types.rs`](https://github.com/leynos/mriya/blob/adopt-whitaker/src/sync/types.rs) — `join_forwarder` extraction.
- [`src/config_store/tests.rs`](https://github.com/leynos/mriya/blob/adopt-whitaker/src/config_store/tests.rs) — fallible fixture and `ensure!`-based assertions.
- [`tests/init/test_doubles.rs`](https://github.com/leynos/mriya/blob/adopt-whitaker/tests/init/test_doubles.rs) and [`tests/run/test_doubles.rs`](https://github.com/leynos/mriya/blob/adopt-whitaker/tests/run/test_doubles.rs) — poison recovery via `PoisonError::into_inner`.
- [`tests/scaleway_backend.rs`](https://github.com/leynos/mriya/blob/adopt-whitaker/tests/scaleway_backend.rs) and [`tests/scaleway_cloud_init.rs`](https://github.com/leynos/mriya/blob/adopt-whitaker/tests/scaleway_cloud_init.rs) — `Result`-stored shared runtimes.

## Validation

- `make check-fmt` — passed.
- `make lint` — passed (`cargo doc`, Clippy, and the Whitaker suite, warnings denied).
- `make typecheck` — passed.
- `make test` — passed (139 tests across all suites; Scaleway integration tests remain env-gated).
- `make markdownlint` — passed (13 files, no errors).
- `make nixie` — passed (all Mermaid diagrams validated).
