### PR TITLE
Wire the CodeScene coverage upload (defer the PR gate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,15 @@ jobs:
         env:
           CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
         if: env.CS_ACCESS_TOKEN != ''
+        # CodeScene's per-project coverage gate is not yet switched on
+        # for this project (see the CI onboarding notes): `cs-coverage
+        # check` errors with "Lacks the gates configuration" until
+        # CodeScene enables it on their side. Enforcement lives in the
+        # separate "CodeScene Code Coverage" check the app posts from
+        # the submitted data, not in this step's exit code, so treat a
+        # submission failure here as non-fatal rather than block the
+        # required build-test job.
+        continue-on-error: true
         uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           format: lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,23 +63,13 @@ jobs:
           format: lcov
           use-cargo-nextest: 'false'
           with-ratchet: 'true'
-      - name: Check coverage against CodeScene gates
-        env:
-          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
-        if: env.CS_ACCESS_TOKEN != ''
-        # CodeScene's per-project coverage gate is not yet switched on
-        # for this project (see the CI onboarding notes): `cs-coverage
-        # check` errors with "Lacks the gates configuration" until
-        # CodeScene enables it on their side. Enforcement lives in the
-        # separate "CodeScene Code Coverage" check the app posts from
-        # the submitted data, not in this step's exit code, so treat a
-        # submission failure here as non-fatal rather than block the
-        # required build-test job.
-        continue-on-error: true
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
-        with:
-          format: lcov
-          mode: check
-          project-url: https://api.codescene.io/v2/projects/74420
-          access-token: ${{ env.CS_ACCESS_TOKEN }}
-          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}
+      # The `mode: check` step is deliberately not wired in yet: CodeScene
+      # project 74420 has no coverage-gates configuration, so
+      # `cs-coverage check` fails every run with "HTTP call succeeded,
+      # but the received project-config isn't valid. Lacks the gates
+      # configuration." — a CodeScene-side per-project setting, not a CI
+      # defect (ddlint and chutoro's projects hit the byte-identical
+      # error). Add the check step in a fast-follow PR once
+      # coverage-main.yml has uploaded to main at least once and the
+      # gate is confirmed to resolve, or once CodeScene confirms the
+      # project's coverage gate is enabled.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,10 @@ jobs:
       WHITAKER_INSTALLER_VERSION: '0.2.5'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          fetch-depth: 0
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
       - name: Format
         run: make check-fmt
       - name: Markdown lint
@@ -55,16 +57,20 @@ jobs:
       - name: Workflow contract tests
         run: make test-workflow-contracts
       - name: Test and Measure Coverage
-        uses: leynos/shared-actions/.github/actions/generate-coverage@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           output-path: lcov.info
           format: lcov
-      - name: Upload coverage data to CodeScene
+          use-cargo-nextest: 'false'
+          with-ratchet: 'true'
+      - name: Check coverage against CodeScene gates
         env:
           CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
-        if: ${{ env.CS_ACCESS_TOKEN }}
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+        if: env.CS_ACCESS_TOKEN != ''
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           format: lcov
+          mode: check
+          project-url: https://api.codescene.io/v2/projects/74420
           access-token: ${{ env.CS_ACCESS_TOKEN }}
           installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -1,0 +1,41 @@
+name: Coverage (main)
+
+# CodeScene accepts `cs-coverage upload` only for analysed branches, so
+# main-branch coverage is uploaded here on push; pull requests run the
+# changed-line gate (`cs-coverage check`) in ci.yml instead. This
+# workflow also advances the coverage ratchet baseline: caches saved on
+# main are readable by every pull-request run, so the baseline written
+# here is the one PR ratchet checks compare against.
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  coverage-upload:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      CARGO_TERM_COLOR: always
+      BUILD_PROFILE: debug
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - name: Setup Rust
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+      - name: Generate coverage
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          output-path: lcov.info
+          format: lcov
+          use-cargo-nextest: 'false'
+          with-ratchet: 'true'
+      - name: Upload coverage data to CodeScene
+        env:
+          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+        if: env.CS_ACCESS_TOKEN != ''
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: lcov
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -28,6 +28,6 @@ jobs:
       # The token is not used for any external cloud auth.
       id-token: write
     if: ${{ github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' }}
-    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@80935e57261986b39b958d7873435a50f14d592e
+    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
     with:
       pull-request-number: ${{ inputs.pull-request-number || github.event.pull_request.number }}

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # OIDC workflow-source resolution
-    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@859416a90eb3987b46a57682c5d6b8964ad3f0a6
+    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
     with:
       # src/test_support.rs is test scaffolding compiled into the
       # library unconditionally (unlike the #[cfg(test)]-gated

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ concurrency:
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}
-  SHARED_ACTIONS_REF: df81280dcc1d6e66134114dbc924313328b15f05
+  SHARED_ACTIONS_REF: 927edd45ae77be4251a8a18ca9eb5613a2e32cbd
 
 jobs:
   metadata:
@@ -60,7 +60,7 @@ jobs:
       - id: release_modes
         name: Determine release modes
         uses: >-
-          leynos/shared-actions/.github/actions/determine-release-modes@df81280dcc1d6e66134114dbc924313328b15f05
+          leynos/shared-actions/.github/actions/determine-release-modes@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           dry-run: ${{ inputs.dry-run }}
           publish: ${{ inputs.publish }}
@@ -68,14 +68,14 @@ jobs:
       - id: ensure_version
         name: Read package version from Cargo.toml
         uses: >-
-          leynos/shared-actions/.github/actions/ensure-cargo-version@df81280dcc1d6e66134114dbc924313328b15f05
+          leynos/shared-actions/.github/actions/ensure-cargo-version@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           check-tag: ${{ fromJSON(steps.release_modes.outputs.should-publish) }}
 
       - id: bin_name
         name: Extract binary name from Cargo.toml
         uses: >-
-          leynos/shared-actions/.github/actions/export-cargo-metadata@df81280dcc1d6e66134114dbc924313328b15f05
+          leynos/shared-actions/.github/actions/export-cargo-metadata@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           fields: bin-name
           export-to-env: 'false'
@@ -126,7 +126,7 @@ jobs:
 
       - name: Build release binary
         uses: >-
-          leynos/shared-actions/.github/actions/rust-build-release@df81280dcc1d6e66134114dbc924313328b15f05
+          leynos/shared-actions/.github/actions/rust-build-release@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           target: ${{ matrix.target }}
           bin-name: ${{ needs.metadata.outputs.bin_name }}
@@ -207,7 +207,7 @@ jobs:
 
       - name: Package Linux artefacts
         uses: >-
-          leynos/shared-actions/.github/actions/linux-packages@80935e57261986b39b958d7873435a50f14d592e
+          leynos/shared-actions/.github/actions/linux-packages@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           project-dir: .
           package-name: ${{ needs.metadata.outputs.bin_name }}
@@ -257,7 +257,7 @@ jobs:
       - name: Build macOS installer package
         id: package_macos
         uses: >-
-          leynos/shared-actions/.github/actions/macos-package@df81280dcc1d6e66134114dbc924313328b15f05
+          leynos/shared-actions/.github/actions/macos-package@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           name: ${{ needs.metadata.outputs.bin_name }}
           identifier: net.df12.mriya

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -23,7 +23,7 @@ WORKFLOW_PATH = (
 
 #: The leynos/shared-actions commit the caller pins. Bump the workflow
 #: and this constant together.
-PINNED_SHA = "859416a90eb3987b46a57682c5d6b8964ad3f0a6"
+PINNED_SHA = "927edd45ae77be4251a8a18ca9eb5613a2e32cbd"
 
 EXPECTED_USES = (
     "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA


### PR DESCRIPTION
## Summary

- Bump every `leynos/shared-actions` reference (including the newly-added `mutation-testing.yml` caller) to `927edd45ae77be4251a8a18ca9eb5613a2e32cbd`, which includes the fixed `upload-codescene-coverage` action (the CLI version-extraction bug that killed the step under `pipefail`) and the new `mode: check` gate.
- Switch the coverage step in [`ci.yml`](https://github.com/leynos/mriya/blob/codescene-coverage-gate/.github/workflows/ci.yml) to a full-history checkout (`fetch-depth: 0`) and enable the coverage ratchet. The `mode: check` gate itself is **deliberately not wired in yet** — see below.
- Add [`coverage-main.yml`](https://github.com/leynos/mriya/blob/codescene-coverage-gate/.github/workflows/coverage-main.yml), which uploads coverage on push to `main` (the only branch CodeScene accepts uploads for) and writes the ratchet baseline that a future PR check would compare against.
- Set `CS_ACCESS_TOKEN` in both the Actions and Dependabot secret stores, so Dependabot-triggered runs no longer silently skip the upload.

## Review walkthrough

- `ci.yml`: the coverage step was already present but pinned to a stale SHA and running with no `CS_ACCESS_TOKEN`, so it was a no-op. `use-cargo-nextest: 'false'` is kept as-is (mriya's `make test` runs plain `cargo test`, so the coverage run stays behaviour-preserving) and `with-ratchet: 'true'` is now on for both the PR and main jobs, per the estate's cache-scope rule (main writes the authoritative baseline; PRs only read it).
- CodeScene project `74420` has no coverage-gates configuration yet — `cs-coverage check` fails every run with `HTTP call succeeded, but the received project-config isn't valid. Lacks the gates configuration.` (a CodeScene-side per-project setting; only mxd's project has it enabled across the estate today). The `mode: check` step is left out with an explanatory comment rather than wired in and made non-fatal, so a future follow-up PR can add it cleanly once the gate resolves.
- `coverage-main.yml` is a single-flavour version of mxd's `coverage-main.yml` (mriya has no feature-split coverage legs, so there is no merge step).
- `release.yml`, `dependabot-automerge.yml`, and `mutation-testing.yml` pins move to the same SHA as part of the repo-wide bump; the `PINNED_SHA` constant in `tests/workflow_contracts/mutation_testing_test.py` moves with it, per that test's own "bump the workflow and this constant together" note.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open(f))"` passed for every workflow file.
- `uv run --with 'pytest>=8' --with 'pyyaml>=6' pytest tests/workflow_contracts -q` — 6 passed.
- `CS_ACCESS_TOKEN` confirmed present in both `gh secret list -R leynos/mriya` and `gh secret list -R leynos/mriya --app dependabot`.

### On the CodeScene rollup

The CodeScene "Code Coverage" check is **not** a required check in this repo's branch protection ruleset (`build-test` and `release / metadata` are); it can still block PR merges through the GitHub status rollup, which Dependabot automerge reads as a whole. This PR only wires the CI side so coverage data can reach CodeScene once its gate is switched on; that switch is a CodeScene-side, per-project decision this PR cannot make.
