### PR TITLE
Kill mutation-testing survivors (#55, #56, #57, #58, #59)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -8,13 +8,10 @@ exclude_re = [
     # tests can script the binary. No production path executes these
     # functions, so their mutants are noise (mirrors the existing
     # src/test_support.rs exclusion).
-    "replace enable_fake_modes",
-    "in fake_run_from_env",
-    "replace fake_run_from_env",
-    "in fake_dump_request",
-    "replace fake_dump_request",
-    "in prefail_from_env",
-    "replace prefail_from_env",
+    "enable_fake_modes",
+    "fake_run_from_env",
+    "fake_dump_request",
+    "prefail_from_env",
     # Equivalent mutant: InstanceRequestBuilder::new() is defined as
     # Self::default(), so replacing the builder body with
     # Default::default() cannot change behaviour.

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,0 +1,22 @@
+# cargo-mutants configuration. These pattern exclusions complement the
+# `exclude-globs: "src/test_support.rs"` input passed by
+# .github/workflows/mutation-testing.yml; cargo-mutants merges both.
+
+exclude_re = [
+    # Test-backdoor scaffolding in src/main.rs, compiled only under
+    # cfg(any(test, feature = "test-backdoors")) so the CLI behaviour
+    # tests can script the binary. No production path executes these
+    # functions, so their mutants are noise (mirrors the existing
+    # src/test_support.rs exclusion).
+    "replace enable_fake_modes",
+    "in fake_run_from_env",
+    "replace fake_run_from_env",
+    "in fake_dump_request",
+    "replace fake_dump_request",
+    "in prefail_from_env",
+    "replace prefail_from_env",
+    # Equivalent mutant: InstanceRequestBuilder::new() is defined as
+    # Self::default(), so replacing the builder body with
+    # Default::default() cannot change behaviour.
+    'replace InstanceRequest::builder -> InstanceRequestBuilder with Default::default\(\)',
+]

--- a/src/config_store/tests.rs
+++ b/src/config_store/tests.rs
@@ -213,3 +213,30 @@ fn current_volume_id_returns_none_when_config_missing(
     );
     Ok(())
 }
+
+#[rstest]
+fn path_exists_reports_non_directory_parent(
+    config_fixture: anyhow::Result<ConfigFixture>,
+) -> anyhow::Result<()> {
+    let fixture = config_fixture?;
+    // Seed a regular file, then probe a path that uses it as a parent
+    // directory: opening it fails with NotADirectory, which must surface
+    // as an Io error rather than being swallowed as "does not exist".
+    fixture
+        .store
+        .write_volume_id("vol-123", true)
+        .context("seed config should succeed")?;
+    let nested = fixture.path.join("mriya.toml");
+
+    let Err(err) = path_exists(&nested) else {
+        bail!("probe through a file should fail");
+    };
+    let ConfigStoreError::Io { path, .. } = err else {
+        bail!("expected io error, got {err:?}");
+    };
+    ensure!(
+        path == fixture.path,
+        "error should cite the non-directory parent"
+    );
+    Ok(())
+}

--- a/src/config_store/tests.rs
+++ b/src/config_store/tests.rs
@@ -176,3 +176,40 @@ fn read_volume_id_rejects_non_table_root(
     ensure!(path == fixture.path, "error should cite the config path");
     Ok(())
 }
+
+#[rstest]
+fn current_volume_id_round_trips_written_id(
+    config_fixture: anyhow::Result<ConfigFixture>,
+) -> anyhow::Result<()> {
+    let fixture = config_fixture?;
+    fixture
+        .store
+        .write_volume_id("vol-123", false)
+        .context("write volume id should succeed")?;
+
+    let volume_id = fixture
+        .store
+        .current_volume_id()
+        .context("read volume id should succeed")?;
+    ensure!(
+        volume_id.as_deref() == Some("vol-123"),
+        "expected the exact written id, got {volume_id:?}"
+    );
+    Ok(())
+}
+
+#[rstest]
+fn current_volume_id_returns_none_when_config_missing(
+    config_fixture: anyhow::Result<ConfigFixture>,
+) -> anyhow::Result<()> {
+    let fixture = config_fixture?;
+    let volume_id = fixture
+        .store
+        .current_volume_id()
+        .context("read of a missing config should succeed")?;
+    ensure!(
+        volume_id.is_none(),
+        "expected None without a config file, got {volume_id:?}"
+    );
+    Ok(())
+}

--- a/src/config_store/tests.rs
+++ b/src/config_store/tests.rs
@@ -177,6 +177,7 @@ fn read_volume_id_rejects_non_table_root(
     Ok(())
 }
 
+// Kills the `current_volume_id` and `path_exists` survivors tracked in #55.
 #[rstest]
 fn current_volume_id_round_trips_written_id(
     config_fixture: anyhow::Result<ConfigFixture>,

--- a/src/init/helpers.rs
+++ b/src/init/helpers.rs
@@ -59,7 +59,10 @@ mod tests {
     #[test]
     fn volume_size_bytes_converts_gb() {
         let bytes = volume_size_bytes(2).expect("size bytes");
-        assert_eq!(bytes, 2 * BYTES_PER_GB);
+        // Assert the literal value: comparing against `2 * BYTES_PER_GB`
+        // mutates together with the constant under test, making the
+        // assertion tautological.
+        assert_eq!(bytes, 2_147_483_648);
     }
 
     #[rstest]

--- a/src/init/helpers.rs
+++ b/src/init/helpers.rs
@@ -61,7 +61,7 @@ mod tests {
         let bytes = volume_size_bytes(2).expect("size bytes");
         // Assert the literal value: comparing against `2 * BYTES_PER_GB`
         // mutates together with the constant under test, making the
-        // assertion tautological.
+        // assertion tautological. Kills the survivor tracked in #56.
         assert_eq!(bytes, 2_147_483_648);
     }
 

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -326,3 +326,6 @@ fn append_teardown_note<E: Display>(message: String, teardown_error: Option<&E>)
         message
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/init/tests.rs
+++ b/src/init/tests.rs
@@ -3,7 +3,7 @@
 use rstest::rstest;
 
 use super::{InitConfig, InitConfigError, format_failure_message};
-use crate::sync::RemoteCommandOutput;
+use crate::sync::{RemoteCommandOutput, SyncError};
 
 #[test]
 fn validate_rejects_zero_volume_size() {
@@ -38,4 +38,31 @@ fn format_failure_message_covers_every_arm(
         stderr: stderr.to_owned(),
     };
     assert_eq!(format_failure_message(&output), expected);
+}
+
+#[test]
+fn format_failure_display_writes_the_message() {
+    let failure = super::FormatFailure {
+        message: String::from("mkfs.ext4 exited with status 1"),
+        source: None,
+    };
+    assert_eq!(failure.to_string(), "mkfs.ext4 exited with status 1");
+}
+
+#[test]
+fn append_teardown_note_returns_message_unchanged_without_error() {
+    let note = super::append_teardown_note::<SyncError>(String::from("provision failed"), None);
+    assert_eq!(note, "provision failed");
+}
+
+#[test]
+fn append_teardown_note_appends_teardown_failure() {
+    let teardown = SyncError::InvalidConfig {
+        field: String::from("ssh_user"),
+    };
+    let note = super::append_teardown_note(String::from("provision failed"), Some(&teardown));
+    assert_eq!(
+        note,
+        format!("provision failed (teardown also failed: {teardown})")
+    );
 }

--- a/src/init/tests.rs
+++ b/src/init/tests.rs
@@ -1,4 +1,7 @@
 //! Unit tests for init configuration validation and mkfs failure messages.
+//!
+//! Kills the init validation and mkfs failure-message survivors tracked in
+//! #56.
 
 use rstest::rstest;
 

--- a/src/init/tests.rs
+++ b/src/init/tests.rs
@@ -1,0 +1,41 @@
+//! Unit tests for init configuration validation and mkfs failure messages.
+
+use rstest::rstest;
+
+use super::{InitConfig, InitConfigError, format_failure_message};
+use crate::sync::RemoteCommandOutput;
+
+#[test]
+fn validate_rejects_zero_volume_size() {
+    let config = InitConfig { volume_size_gb: 0 };
+    let result = config.validate();
+    assert!(
+        matches!(result, Err(InitConfigError::InvalidVolumeSize)),
+        "expected InvalidVolumeSize for zero size, got {result:?}"
+    );
+}
+
+#[test]
+fn validate_accepts_non_zero_volume_size() {
+    let config = InitConfig { volume_size_gb: 20 };
+    let result = config.validate();
+    assert!(result.is_ok(), "expected Ok for non-zero size: {result:?}");
+}
+
+#[rstest]
+#[case(Some(1), "", "mkfs.ext4 exited with status 1")]
+#[case(Some(1), "boom\n", "mkfs.ext4 exited with status 1: boom")]
+#[case(None, "", "mkfs.ext4 terminated without an exit status")]
+#[case(None, "boom\n", "mkfs.ext4 terminated without an exit status: boom")]
+fn format_failure_message_covers_every_arm(
+    #[case] exit_code: Option<i32>,
+    #[case] stderr: &str,
+    #[case] expected: &str,
+) {
+    let output = RemoteCommandOutput {
+        exit_code,
+        stdout: String::new(),
+        stderr: stderr.to_owned(),
+    };
+    assert_eq!(format_failure_message(&output), expected);
+}

--- a/src/scaleway/lifecycle/tests/mod.rs
+++ b/src/scaleway/lifecycle/tests/mod.rs
@@ -129,5 +129,20 @@ async fn power_on_if_needed_errors_when_not_allowed(backend_fixture: ScalewayBac
     );
 }
 
+#[rstest]
+#[tokio::test]
+async fn power_on_if_needed_ignores_non_poweron_actions(backend_fixture: ScalewayBackend) {
+    // A stopped instance offering only unrelated actions must be reported
+    // as not powerable; only an exact "poweron" action may trigger the
+    // power-on request.
+    let snap = snapshot("id", "stopped", [Action::from("reboot")], None);
+    let zone = Zone::from("zone");
+    let result = backend_fixture.power_on_if_needed(&zone, &snap).await;
+    assert!(
+        matches!(result, Err(ScalewayBackendError::PowerOnNotAllowed { .. })),
+        "expected PowerOnNotAllowed error, got {result:?}"
+    );
+}
+
 mod image;
 mod wait;

--- a/src/scaleway/lifecycle/tests/mod.rs
+++ b/src/scaleway/lifecycle/tests/mod.rs
@@ -129,6 +129,7 @@ async fn power_on_if_needed_errors_when_not_allowed(backend_fixture: ScalewayBac
     );
 }
 
+// Kills the `power_on_if_needed` equality-mutant survivor tracked in #58.
 #[rstest]
 #[tokio::test]
 async fn power_on_if_needed_ignores_non_poweron_actions(backend_fixture: ScalewayBackend) {

--- a/src/scaleway/lifecycle/tests/wait.rs
+++ b/src/scaleway/lifecycle/tests/wait.rs
@@ -17,13 +17,21 @@ use crate::scaleway::DEFAULT_SSH_PORT;
 use crate::scaleway::types::Action;
 use crate::scaleway::{ScalewayBackend, ScalewayBackendError};
 
-use super::super::wait::{poll_for_public_ip, poll_until_gone};
+use super::super::wait::{PollSettings, poll_for_public_ip, poll_until_gone};
 use super::InstanceSnapshot;
 
 type FetchResult = Result<Option<InstanceSnapshot>, ScalewayBackendError>;
 
 const POLL_INTERVAL: Duration = Duration::from_millis(1);
 const WAIT_TIMEOUT: Duration = Duration::from_millis(50);
+
+fn poll_settings(wait_timeout: Duration) -> PollSettings {
+    PollSettings {
+        ssh_port: DEFAULT_SSH_PORT,
+        poll_interval: POLL_INTERVAL,
+        wait_timeout,
+    }
+}
 
 /// Returns a fetch closure yielding the given snapshots in order, then
 /// `None` once the script is exhausted.
@@ -55,15 +63,9 @@ async fn wait_for_public_ip_returns_networking_once_running() {
             Some("192.0.2.10"),
         )),
     ]);
-    let networking = poll_for_public_ip(
-        &handle(),
-        DEFAULT_SSH_PORT,
-        POLL_INTERVAL,
-        WAIT_TIMEOUT,
-        fetch,
-    )
-    .await
-    .unwrap_or_else(|err| panic!("expected networking, got {err}"));
+    let networking = poll_for_public_ip(&handle(), poll_settings(WAIT_TIMEOUT), fetch)
+        .await
+        .unwrap_or_else(|err| panic!("expected networking, got {err}"));
     let expected_ip =
         IpAddr::from_str("192.0.2.10").unwrap_or_else(|err| panic!("ip parse: {err}"));
     assert_eq!(networking.public_ip, expected_ip);
@@ -76,14 +78,8 @@ async fn wait_for_public_ip_returns_missing_ip() {
         Some(super::snapshot("id", "running", Vec::<Action>::new(), None)),
         Some(super::snapshot("id", "running", Vec::<Action>::new(), None)),
     ]);
-    let result = poll_for_public_ip(
-        &handle(),
-        DEFAULT_SSH_PORT,
-        POLL_INTERVAL,
-        Duration::from_millis(5),
-        fetch,
-    )
-    .await;
+    let result =
+        poll_for_public_ip(&handle(), poll_settings(Duration::from_millis(5)), fetch).await;
     assert!(
         matches!(result, Err(ScalewayBackendError::MissingPublicIp { .. })),
         "unexpected wait_for_public_ip outcome: {result:?}"

--- a/src/scaleway/lifecycle/tests/wait.rs
+++ b/src/scaleway/lifecycle/tests/wait.rs
@@ -1,114 +1,114 @@
 //! Tests for Scaleway readiness and teardown wait loops.
+//!
+//! The polling loops are exercised directly through the production
+//! `poll_for_public_ip` and `poll_until_gone` helpers with scripted fetch
+//! closures, so mutations to the loop bodies are observable.
 
 use std::collections::VecDeque;
+use std::future::{Ready, ready};
 use std::net::IpAddr;
 use std::str::FromStr;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use scaleway_rs::ScalewayApi;
-use tokio::time::sleep;
 
 use crate::backend::{InstanceHandle, InstanceNetworking};
 use crate::scaleway::DEFAULT_SSH_PORT;
 use crate::scaleway::types::Action;
 use crate::scaleway::{ScalewayBackend, ScalewayBackendError};
 
+use super::super::wait::{poll_for_public_ip, poll_until_gone};
 use super::InstanceSnapshot;
 
-/// Minimal backend double to test wait loops without real API calls.
-struct FakeBackend {
-    snapshots: VecDeque<Option<InstanceSnapshot>>,
-    poll_interval: Duration,
-    wait_timeout: Duration,
-    ssh_port: u16,
+type FetchResult = Result<Option<InstanceSnapshot>, ScalewayBackendError>;
+
+const POLL_INTERVAL: Duration = Duration::from_millis(1);
+const WAIT_TIMEOUT: Duration = Duration::from_millis(50);
+
+/// Returns a fetch closure yielding the given snapshots in order, then
+/// `None` once the script is exhausted.
+fn scripted_fetch(snapshots: Vec<Option<InstanceSnapshot>>) -> impl FnMut() -> Ready<FetchResult> {
+    let mut queue = VecDeque::from(snapshots);
+    move || ready(Ok(queue.pop_front().unwrap_or(None)))
 }
 
-impl FakeBackend {
-    async fn wait_for_public_ip(
-        &mut self,
-        handle: &InstanceHandle,
-    ) -> Result<InstanceNetworking, ScalewayBackendError> {
-        let deadline = Instant::now() + self.wait_timeout;
-        let mut saw_running = false;
-
-        while Instant::now() <= deadline {
-            let server_opt = self.snapshots.pop_front().unwrap_or(None);
-            let Some(server) = server_opt else {
-                sleep(self.poll_interval).await;
-                continue;
-            };
-
-            if server.state.as_str() != "running" {
-                sleep(self.poll_interval).await;
-                continue;
-            }
-
-            saw_running = true;
-
-            if let Some(address) = server
-                .public_ip
-                .as_ref()
-                .and_then(|ip| IpAddr::from_str(ip).ok())
-            {
-                return Ok(InstanceNetworking {
-                    public_ip: address,
-                    ssh_port: self.ssh_port,
-                });
-            }
-
-            sleep(self.poll_interval).await;
-        }
-
-        if saw_running {
-            return Err(ScalewayBackendError::MissingPublicIp {
-                instance_id: handle.id.clone(),
-            });
-        }
-
-        Err(ScalewayBackendError::Timeout {
-            action: "wait_for_ready".to_owned(),
-            instance_id: handle.id.clone(),
-        })
-    }
-
-    async fn wait_until_gone(
-        &mut self,
-        handle: &InstanceHandle,
-    ) -> Result<(), ScalewayBackendError> {
-        let deadline = Instant::now() + self.wait_timeout;
-        while Instant::now() <= deadline {
-            let next = self.snapshots.pop_front().unwrap_or(None);
-            if next.is_none() {
-                return Ok(());
-            }
-            sleep(self.poll_interval).await;
-        }
-        Err(ScalewayBackendError::ResidualResource {
-            instance_id: handle.id.clone(),
-        })
+fn handle() -> InstanceHandle {
+    InstanceHandle {
+        id: "id".to_owned(),
+        zone: "zone".to_owned(),
     }
 }
 
 #[tokio::test]
+async fn wait_for_public_ip_returns_networking_once_running() {
+    let fetch = scripted_fetch(vec![
+        Some(super::snapshot(
+            "id",
+            "starting",
+            Vec::<Action>::new(),
+            None,
+        )),
+        Some(super::snapshot(
+            "id",
+            "running",
+            Vec::<Action>::new(),
+            Some("192.0.2.10"),
+        )),
+    ]);
+    let networking = poll_for_public_ip(
+        &handle(),
+        DEFAULT_SSH_PORT,
+        POLL_INTERVAL,
+        WAIT_TIMEOUT,
+        fetch,
+    )
+    .await
+    .unwrap_or_else(|err| panic!("expected networking, got {err}"));
+    let expected_ip =
+        IpAddr::from_str("192.0.2.10").unwrap_or_else(|err| panic!("ip parse: {err}"));
+    assert_eq!(networking.public_ip, expected_ip);
+    assert_eq!(networking.ssh_port, DEFAULT_SSH_PORT);
+}
+
+#[tokio::test]
 async fn wait_for_public_ip_returns_missing_ip() {
-    let mut fake = FakeBackend {
-        snapshots: VecDeque::from(vec![
-            Some(super::snapshot("id", "running", Vec::<Action>::new(), None)),
-            Some(super::snapshot("id", "running", Vec::<Action>::new(), None)),
-        ]),
-        poll_interval: Duration::from_millis(1),
-        wait_timeout: Duration::from_millis(5),
-        ssh_port: DEFAULT_SSH_PORT,
-    };
-    let handle = InstanceHandle {
-        id: "id".to_owned(),
-        zone: "zone".to_owned(),
-    };
-    let result = fake.wait_for_public_ip(&handle).await;
+    let fetch = scripted_fetch(vec![
+        Some(super::snapshot("id", "running", Vec::<Action>::new(), None)),
+        Some(super::snapshot("id", "running", Vec::<Action>::new(), None)),
+    ]);
+    let result = poll_for_public_ip(
+        &handle(),
+        DEFAULT_SSH_PORT,
+        POLL_INTERVAL,
+        Duration::from_millis(5),
+        fetch,
+    )
+    .await;
     assert!(
         matches!(result, Err(ScalewayBackendError::MissingPublicIp { .. })),
         "unexpected wait_for_public_ip outcome: {result:?}"
     );
+}
+
+#[tokio::test]
+async fn wait_until_gone_returns_ok_when_instance_absent() {
+    let fetch = scripted_fetch(vec![None]);
+    let result = poll_until_gone(&handle(), POLL_INTERVAL, WAIT_TIMEOUT, fetch).await;
+    assert!(
+        result.is_ok(),
+        "expected Ok for absent instance: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn wait_until_gone_times_out_on_residual() {
+    let snapshot = super::snapshot("id", "running", Vec::<Action>::new(), None);
+    let fetch = move || ready(Ok(Some(snapshot.clone())));
+    let result = poll_until_gone(&handle(), POLL_INTERVAL, Duration::from_millis(2), fetch).await;
+    assert!(matches!(
+        result,
+        Err(ScalewayBackendError::ResidualResource { .. })
+    ));
 }
 
 #[tokio::test]
@@ -130,16 +130,12 @@ async fn wait_for_ssh_ready_succeeds_when_port_listens() {
         wait_timeout: Duration::from_millis(200),
     };
 
-    let handle = InstanceHandle {
-        id: String::from("id"),
-        zone: String::from("zone"),
-    };
     let networking = InstanceNetworking {
         public_ip: addr.ip(),
         ssh_port: addr.port(),
     };
     backend
-        .wait_for_ssh_ready(&handle, &networking)
+        .wait_for_ssh_ready(&handle(), &networking)
         .await
         .unwrap_or_else(|err| panic!("ssh should be reachable: {err}"));
 }
@@ -163,42 +159,14 @@ async fn wait_for_ssh_ready_times_out_when_port_closed() {
         wait_timeout: Duration::from_millis(50),
     };
 
-    let handle = InstanceHandle {
-        id: String::from("id"),
-        zone: String::from("zone"),
-    };
     let networking = InstanceNetworking {
         public_ip: IpAddr::from_str("127.0.0.1")
             .unwrap_or_else(|err| panic!("loopback ip parse: {err}")),
         ssh_port: addr.port(),
     };
     let err = backend
-        .wait_for_ssh_ready(&handle, &networking)
+        .wait_for_ssh_ready(&handle(), &networking)
         .await
         .expect_err("expected timeout");
     assert!(matches!(err, ScalewayBackendError::Timeout { .. }));
-}
-
-#[tokio::test]
-async fn wait_until_gone_times_out_on_residual() {
-    let mut fake = FakeBackend {
-        snapshots: VecDeque::from(vec![Some(super::snapshot(
-            "id",
-            "running",
-            Vec::<Action>::new(),
-            None,
-        ))]),
-        poll_interval: Duration::from_millis(1),
-        wait_timeout: Duration::from_millis(2),
-        ssh_port: DEFAULT_SSH_PORT,
-    };
-    let handle = InstanceHandle {
-        id: "id".to_owned(),
-        zone: "zone".to_owned(),
-    };
-    let result = fake.wait_until_gone(&handle).await;
-    assert!(matches!(
-        result,
-        Err(ScalewayBackendError::ResidualResource { .. })
-    ));
 }

--- a/src/scaleway/lifecycle/tests/wait.rs
+++ b/src/scaleway/lifecycle/tests/wait.rs
@@ -2,7 +2,8 @@
 //!
 //! The polling loops are exercised directly through the production
 //! `poll_for_public_ip` and `poll_until_gone` helpers with scripted fetch
-//! closures, so mutations to the loop bodies are observable.
+//! closures, so mutations to the loop bodies are observable. Kills the
+//! wait-loop survivors tracked in #58.
 
 use std::collections::VecDeque;
 use std::future::{Ready, ready};

--- a/src/scaleway/lifecycle/tests/wait.rs
+++ b/src/scaleway/lifecycle/tests/wait.rs
@@ -11,6 +11,7 @@ use std::net::IpAddr;
 use std::str::FromStr;
 use std::time::Duration;
 
+use rstest::{fixture, rstest};
 use scaleway_rs::ScalewayApi;
 
 use crate::backend::{InstanceHandle, InstanceNetworking};
@@ -41,6 +42,7 @@ fn scripted_fetch(snapshots: Vec<Option<InstanceSnapshot>>) -> impl FnMut() -> R
     move || ready(Ok(queue.pop_front().unwrap_or(None)))
 }
 
+#[fixture]
 fn handle() -> InstanceHandle {
     InstanceHandle {
         id: "id".to_owned(),
@@ -48,8 +50,9 @@ fn handle() -> InstanceHandle {
     }
 }
 
+#[rstest]
 #[tokio::test]
-async fn wait_for_public_ip_returns_networking_once_running() {
+async fn wait_for_public_ip_returns_networking_once_running(handle: InstanceHandle) {
     let fetch = scripted_fetch(vec![
         Some(super::snapshot(
             "id",
@@ -64,7 +67,7 @@ async fn wait_for_public_ip_returns_networking_once_running() {
             Some("192.0.2.10"),
         )),
     ]);
-    let networking = poll_for_public_ip(&handle(), poll_settings(WAIT_TIMEOUT), fetch)
+    let networking = poll_for_public_ip(&handle, poll_settings(WAIT_TIMEOUT), fetch)
         .await
         .unwrap_or_else(|err| panic!("expected networking, got {err}"));
     let expected_ip =
@@ -73,43 +76,46 @@ async fn wait_for_public_ip_returns_networking_once_running() {
     assert_eq!(networking.ssh_port, DEFAULT_SSH_PORT);
 }
 
+#[rstest]
 #[tokio::test]
-async fn wait_for_public_ip_returns_missing_ip() {
+async fn wait_for_public_ip_returns_missing_ip(handle: InstanceHandle) {
     let fetch = scripted_fetch(vec![
         Some(super::snapshot("id", "running", Vec::<Action>::new(), None)),
         Some(super::snapshot("id", "running", Vec::<Action>::new(), None)),
     ]);
-    let result =
-        poll_for_public_ip(&handle(), poll_settings(Duration::from_millis(5)), fetch).await;
+    let result = poll_for_public_ip(&handle, poll_settings(Duration::from_millis(5)), fetch).await;
     assert!(
         matches!(result, Err(ScalewayBackendError::MissingPublicIp { .. })),
         "unexpected wait_for_public_ip outcome: {result:?}"
     );
 }
 
+#[rstest]
 #[tokio::test]
-async fn wait_until_gone_returns_ok_when_instance_absent() {
+async fn wait_until_gone_returns_ok_when_instance_absent(handle: InstanceHandle) {
     let fetch = scripted_fetch(vec![None]);
-    let result = poll_until_gone(&handle(), POLL_INTERVAL, WAIT_TIMEOUT, fetch).await;
+    let result = poll_until_gone(&handle, POLL_INTERVAL, WAIT_TIMEOUT, fetch).await;
     assert!(
         result.is_ok(),
         "expected Ok for absent instance: {result:?}"
     );
 }
 
+#[rstest]
 #[tokio::test]
-async fn wait_until_gone_times_out_on_residual() {
+async fn wait_until_gone_times_out_on_residual(handle: InstanceHandle) {
     let snapshot = super::snapshot("id", "running", Vec::<Action>::new(), None);
     let fetch = move || ready(Ok(Some(snapshot.clone())));
-    let result = poll_until_gone(&handle(), POLL_INTERVAL, Duration::from_millis(2), fetch).await;
+    let result = poll_until_gone(&handle, POLL_INTERVAL, Duration::from_millis(2), fetch).await;
     assert!(matches!(
         result,
         Err(ScalewayBackendError::ResidualResource { .. })
     ));
 }
 
+#[rstest]
 #[tokio::test]
-async fn wait_for_ssh_ready_succeeds_when_port_listens() {
+async fn wait_for_ssh_ready_succeeds_when_port_listens(handle: InstanceHandle) {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
         .unwrap_or_else(|err| panic!("bind listener: {err}"));
@@ -132,13 +138,14 @@ async fn wait_for_ssh_ready_succeeds_when_port_listens() {
         ssh_port: addr.port(),
     };
     backend
-        .wait_for_ssh_ready(&handle(), &networking)
+        .wait_for_ssh_ready(&handle, &networking)
         .await
         .unwrap_or_else(|err| panic!("ssh should be reachable: {err}"));
 }
 
+#[rstest]
 #[tokio::test]
-async fn wait_for_ssh_ready_times_out_when_port_closed() {
+async fn wait_for_ssh_ready_times_out_when_port_closed(handle: InstanceHandle) {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
         .unwrap_or_else(|err| panic!("bind listener: {err}"));
@@ -162,7 +169,7 @@ async fn wait_for_ssh_ready_times_out_when_port_closed() {
         ssh_port: addr.port(),
     };
     let err = backend
-        .wait_for_ssh_ready(&handle(), &networking)
+        .wait_for_ssh_ready(&handle, &networking)
         .await
         .expect_err("expected timeout");
     assert!(matches!(err, ScalewayBackendError::Timeout { .. }));

--- a/src/scaleway/lifecycle/wait.rs
+++ b/src/scaleway/lifecycle/wait.rs
@@ -1,5 +1,10 @@
 //! Readiness and teardown wait helpers for the Scaleway backend.
+//!
+//! The polling loops are generic over an instance-fetch closure so unit
+//! tests can drive the production loop bodies with scripted snapshots
+//! instead of duplicating the algorithm against a fake backend.
 
+use std::future::Future;
 use std::net::IpAddr;
 use std::str::FromStr;
 use std::time::{Duration, Instant};
@@ -44,46 +49,14 @@ impl ScalewayBackend {
         &self,
         handle: &InstanceHandle,
     ) -> Result<InstanceNetworking, ScalewayBackendError> {
-        let deadline = Instant::now() + self.wait_timeout;
-        let mut saw_running = false;
-
-        while Instant::now() <= deadline {
-            let Some(server) = self.fetch_instance(handle).await? else {
-                sleep(self.poll_interval).await;
-                continue;
-            };
-
-            if server.state.as_str() != "running" {
-                sleep(self.poll_interval).await;
-                continue;
-            }
-
-            saw_running = true;
-
-            if let Some(address) = server
-                .public_ip
-                .as_ref()
-                .and_then(|ip| IpAddr::from_str(ip).ok())
-            {
-                return Ok(InstanceNetworking {
-                    public_ip: address,
-                    ssh_port: self.ssh_port,
-                });
-            }
-
-            sleep(self.poll_interval).await;
-        }
-
-        if saw_running {
-            return Err(ScalewayBackendError::MissingPublicIp {
-                instance_id: handle.id.clone(),
-            });
-        }
-
-        Err(ScalewayBackendError::Timeout {
-            action: "wait_for_ready".to_owned(),
-            instance_id: handle.id.clone(),
-        })
+        poll_for_public_ip(
+            handle,
+            self.ssh_port,
+            self.poll_interval,
+            self.wait_timeout,
+            || self.fetch_instance(handle),
+        )
+        .await
     }
 
     pub(in crate::scaleway) async fn wait_for_ssh_ready(
@@ -111,16 +84,94 @@ impl ScalewayBackend {
         &self,
         handle: &InstanceHandle,
     ) -> Result<(), ScalewayBackendError> {
-        let deadline = Instant::now() + self.wait_timeout;
-        while Instant::now() <= deadline {
-            if self.fetch_instance(handle).await?.is_none() {
-                return Ok(());
-            }
-            sleep(self.poll_interval).await;
+        poll_until_gone(handle, self.poll_interval, self.wait_timeout, || {
+            self.fetch_instance(handle)
+        })
+        .await
+    }
+}
+
+/// Polls `fetch` until the instance reports a running state with a parseable
+/// public IP, or the timeout elapses.
+///
+/// Returns [`ScalewayBackendError::MissingPublicIp`] when a running instance
+/// never exposed an address, and [`ScalewayBackendError::Timeout`] when the
+/// instance never reached the running state.
+pub(super) async fn poll_for_public_ip<F, Fut>(
+    handle: &InstanceHandle,
+    ssh_port: u16,
+    poll_interval: Duration,
+    wait_timeout: Duration,
+    mut fetch: F,
+) -> Result<InstanceNetworking, ScalewayBackendError>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<Option<InstanceSnapshot>, ScalewayBackendError>>,
+{
+    let deadline = Instant::now() + wait_timeout;
+    let mut saw_running = false;
+
+    while Instant::now() <= deadline {
+        let Some(server) = fetch().await? else {
+            sleep(poll_interval).await;
+            continue;
+        };
+
+        if server.state.as_str() != "running" {
+            sleep(poll_interval).await;
+            continue;
         }
 
-        Err(ScalewayBackendError::ResidualResource {
-            instance_id: handle.id.clone(),
-        })
+        saw_running = true;
+
+        if let Some(address) = server
+            .public_ip
+            .as_ref()
+            .and_then(|ip| IpAddr::from_str(ip).ok())
+        {
+            return Ok(InstanceNetworking {
+                public_ip: address,
+                ssh_port,
+            });
+        }
+
+        sleep(poll_interval).await;
     }
+
+    if saw_running {
+        return Err(ScalewayBackendError::MissingPublicIp {
+            instance_id: handle.id.clone(),
+        });
+    }
+
+    Err(ScalewayBackendError::Timeout {
+        action: "wait_for_ready".to_owned(),
+        instance_id: handle.id.clone(),
+    })
+}
+
+/// Polls `fetch` until the instance is no longer listed, or the timeout
+/// elapses, in which case [`ScalewayBackendError::ResidualResource`] is
+/// returned.
+pub(super) async fn poll_until_gone<F, Fut>(
+    handle: &InstanceHandle,
+    poll_interval: Duration,
+    wait_timeout: Duration,
+    mut fetch: F,
+) -> Result<(), ScalewayBackendError>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<Option<InstanceSnapshot>, ScalewayBackendError>>,
+{
+    let deadline = Instant::now() + wait_timeout;
+    while Instant::now() <= deadline {
+        if fetch().await?.is_none() {
+            return Ok(());
+        }
+        sleep(poll_interval).await;
+    }
+
+    Err(ScalewayBackendError::ResidualResource {
+        instance_id: handle.id.clone(),
+    })
 }

--- a/src/scaleway/lifecycle/wait.rs
+++ b/src/scaleway/lifecycle/wait.rs
@@ -49,14 +49,12 @@ impl ScalewayBackend {
         &self,
         handle: &InstanceHandle,
     ) -> Result<InstanceNetworking, ScalewayBackendError> {
-        poll_for_public_ip(
-            handle,
-            self.ssh_port,
-            self.poll_interval,
-            self.wait_timeout,
-            || self.fetch_instance(handle),
-        )
-        .await
+        let settings = PollSettings {
+            ssh_port: self.ssh_port,
+            poll_interval: self.poll_interval,
+            wait_timeout: self.wait_timeout,
+        };
+        poll_for_public_ip(handle, settings, || self.fetch_instance(handle)).await
     }
 
     pub(in crate::scaleway) async fn wait_for_ssh_ready(
@@ -91,6 +89,14 @@ impl ScalewayBackend {
     }
 }
 
+/// Timing and port parameters for the readiness polling loop.
+#[derive(Clone, Copy)]
+pub(super) struct PollSettings {
+    pub(super) ssh_port: u16,
+    pub(super) poll_interval: Duration,
+    pub(super) wait_timeout: Duration,
+}
+
 /// Polls `fetch` until the instance reports a running state with a parseable
 /// public IP, or the timeout elapses.
 ///
@@ -99,15 +105,18 @@ impl ScalewayBackend {
 /// instance never reached the running state.
 pub(super) async fn poll_for_public_ip<F, Fut>(
     handle: &InstanceHandle,
-    ssh_port: u16,
-    poll_interval: Duration,
-    wait_timeout: Duration,
+    settings: PollSettings,
     mut fetch: F,
 ) -> Result<InstanceNetworking, ScalewayBackendError>
 where
     F: FnMut() -> Fut,
     Fut: Future<Output = Result<Option<InstanceSnapshot>, ScalewayBackendError>>,
 {
+    let PollSettings {
+        ssh_port,
+        poll_interval,
+        wait_timeout,
+    } = settings;
     let deadline = Instant::now() + wait_timeout;
     let mut saw_running = false;
 

--- a/src/scaleway/lifecycle/wait.rs
+++ b/src/scaleway/lifecycle/wait.rs
@@ -103,6 +103,30 @@ pub(super) struct PollSettings {
 /// Returns [`ScalewayBackendError::MissingPublicIp`] when a running instance
 /// never exposed an address, and [`ScalewayBackendError::Timeout`] when the
 /// instance never reached the running state.
+///
+/// # Examples
+///
+/// The example is marked `ignore` because the helper is crate-internal and so
+/// is unreachable from a doctest; the equivalent assertions run as unit tests
+/// in `super::tests::wait`.
+///
+/// ```ignore
+/// let mut script = VecDeque::from(vec![
+///     snapshot("id", "starting", [], None),
+///     snapshot("id", "running", [], Some("192.0.2.10")),
+/// ]);
+/// let settings = PollSettings {
+///     ssh_port: 22,
+///     poll_interval: Duration::from_millis(1),
+///     wait_timeout: Duration::from_millis(50),
+/// };
+/// let networking = poll_for_public_ip(&handle, settings, || {
+///     ready(Ok(script.pop_front()))
+/// })
+/// .await?;
+/// assert_eq!(networking.public_ip, IpAddr::from_str("192.0.2.10")?);
+/// assert_eq!(networking.ssh_port, 22);
+/// ```
 pub(super) async fn poll_for_public_ip<F, Fut>(
     handle: &InstanceHandle,
     settings: PollSettings,
@@ -162,6 +186,35 @@ where
 /// Polls `fetch` until the instance is no longer listed, or the timeout
 /// elapses, in which case [`ScalewayBackendError::ResidualResource`] is
 /// returned.
+///
+/// # Examples
+///
+/// As with [`poll_for_public_ip`], the example is `ignore`d because the helper
+/// is crate-internal; the executed equivalents live in `super::tests::wait`.
+///
+/// ```ignore
+/// // The instance is already absent, so the first fetch settles the loop.
+/// poll_until_gone(
+///     &handle,
+///     Duration::from_millis(1),
+///     Duration::from_millis(50),
+///     || ready(Ok(None)),
+/// )
+/// .await?;
+///
+/// // A snapshot that never disappears exhausts the timeout instead.
+/// let residual = poll_until_gone(
+///     &handle,
+///     Duration::from_millis(1),
+///     Duration::from_millis(2),
+///     || ready(Ok(Some(snapshot("id", "running", [], None)))),
+/// )
+/// .await;
+/// assert!(matches!(
+///     residual,
+///     Err(ScalewayBackendError::ResidualResource { .. })
+/// ));
+/// ```
 pub(super) async fn poll_until_gone<F, Fut>(
     handle: &InstanceHandle,
     poll_interval: Duration,

--- a/src/scaleway/mod.rs
+++ b/src/scaleway/mod.rs
@@ -312,39 +312,30 @@ mod tests {
         );
     }
 
-    #[test]
-    fn instance_tags_omits_test_tag_when_unset() {
-        let tags = ScalewayBackend::instance_tags(None);
-        assert_eq!(tags, vec![String::from("mriya"), String::from("ephemeral")]);
+    #[rstest]
+    #[case(ScalewayBackend::instance_tags, "ephemeral")]
+    #[case(ScalewayBackend::volume_tags, "cache")]
+    fn tags_omit_test_tag_when_unset(
+        #[case] tags_fn: fn(Option<&str>) -> Vec<String>,
+        #[case] base_tag: &str,
+    ) {
+        let tags = tags_fn(None);
+        assert_eq!(tags, vec![String::from("mriya"), String::from(base_tag)]);
     }
 
-    #[test]
-    fn instance_tags_adds_test_run_tag() {
-        let tags = ScalewayBackend::instance_tags(Some("run-123"));
+    #[rstest]
+    #[case(ScalewayBackend::instance_tags, "ephemeral")]
+    #[case(ScalewayBackend::volume_tags, "cache")]
+    fn tags_add_test_run_tag(
+        #[case] tags_fn: fn(Option<&str>) -> Vec<String>,
+        #[case] base_tag: &str,
+    ) {
+        let tags = tags_fn(Some("run-123"));
         assert_eq!(
             tags,
             vec![
                 String::from("mriya"),
-                String::from("ephemeral"),
-                String::from("mriya-test-run-run-123"),
-            ]
-        );
-    }
-
-    #[test]
-    fn volume_tags_omits_test_tag_when_unset() {
-        let tags = ScalewayBackend::volume_tags(None);
-        assert_eq!(tags, vec![String::from("mriya"), String::from("cache")]);
-    }
-
-    #[test]
-    fn volume_tags_adds_test_run_tag() {
-        let tags = ScalewayBackend::volume_tags(Some("run-123"));
-        assert_eq!(
-            tags,
-            vec![
-                String::from("mriya"),
-                String::from("cache"),
+                String::from(base_tag),
                 String::from("mriya-test-run-run-123"),
             ]
         );

--- a/src/scaleway/mod.rs
+++ b/src/scaleway/mod.rs
@@ -38,13 +38,15 @@ impl ScalewayBackend {
         api_err: &scaleway_rs::ScalewayApiError,
         request: &InstanceRequest,
     ) -> bool {
+        // A former third clause (`etype == "invalid_arguments"` with a
+        // `commercial_type` resource) was subsumed by the first check and
+        // has been removed: whenever it held, the first clause had already
+        // classified the error.
         matches!(api_err.resource.as_deref(), Some("commercial_type"))
             || api_err
                 .resource_id
                 .as_deref()
                 .is_some_and(|id| id == request.instance_type)
-            || (api_err.etype == "invalid_arguments"
-                && matches!(api_err.resource.as_deref(), Some("commercial_type")))
     }
 
     /// Constructs a new backend from configuration.
@@ -225,8 +227,86 @@ impl VolumeBackend for ScalewayBackend {
 
 #[cfg(test)]
 mod tests {
-    //! Unit tests for Scaleway backend tagging.
+    //! Unit tests for Scaleway backend tagging, error classification, and
+    //! volume validation.
+    use rstest::rstest;
+
     use super::ScalewayBackend;
+    use crate::backend::{InstanceHandle, InstanceRequest};
+    use crate::scaleway::ScalewayBackendError;
+
+    fn api_error(
+        etype: &str,
+        resource: Option<&str>,
+        resource_id: Option<&str>,
+    ) -> scaleway_rs::ScalewayApiError {
+        scaleway_rs::ScalewayApiError {
+            message: String::from("boom"),
+            resource: resource.map(str::to_owned),
+            resource_id: resource_id.map(str::to_owned),
+            etype: etype.to_owned(),
+        }
+    }
+
+    fn request_with_type(instance_type: &str) -> InstanceRequest {
+        InstanceRequest {
+            image_label: String::from("label"),
+            instance_type: instance_type.to_owned(),
+            zone: String::from("zone"),
+            project_id: String::from("proj"),
+            organisation_id: None,
+            architecture: String::from("x86_64"),
+            volume_id: None,
+            cloud_init_user_data: None,
+        }
+    }
+
+    fn handle() -> InstanceHandle {
+        InstanceHandle {
+            id: String::from("instance-1"),
+            zone: String::from("zone"),
+        }
+    }
+
+    #[rstest]
+    // Resource alone identifies the instance type, without a resource_id.
+    #[case(api_error("invalid_arguments", Some("commercial_type"), None), true)]
+    // A resource_id matching the requested type classifies even when the
+    // resource is unrelated.
+    #[case(api_error("unknown", Some("server"), Some("DEV1-S")), true)]
+    // A non-matching resource_id must not classify.
+    #[case(api_error("unknown", Some("server"), Some("GP1-XS")), false)]
+    // An unrelated error must not classify.
+    #[case(api_error("out_of_stock", None, None), false)]
+    fn is_instance_type_error_classifies(
+        #[case] api_err: scaleway_rs::ScalewayApiError,
+        #[case] expected: bool,
+    ) {
+        let request = request_with_type("DEV1-S");
+        assert_eq!(
+            ScalewayBackend::is_instance_type_error(&api_err, &request),
+            expected,
+            "unexpected classification for {api_err:?}"
+        );
+    }
+
+    #[test]
+    fn validate_cache_volume_id_rejects_root_volume() {
+        let result = ScalewayBackend::validate_cache_volume_id(" vol-1 ", "vol-1", &handle());
+        assert!(
+            matches!(
+                result,
+                Err(ScalewayBackendError::VolumeAttachmentFailed { .. })
+            ),
+            "expected VolumeAttachmentFailed for identical ids, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn validate_cache_volume_id_accepts_distinct_volume() {
+        let result = ScalewayBackend::validate_cache_volume_id("vol-1", "vol-2", &handle());
+        assert!(result.is_ok(), "expected Ok for distinct ids: {result:?}");
+    }
 
     #[test]
     fn instance_tags_omits_test_tag_when_unset() {

--- a/src/scaleway/mod.rs
+++ b/src/scaleway/mod.rs
@@ -290,22 +290,26 @@ mod tests {
         );
     }
 
-    #[test]
-    fn validate_cache_volume_id_rejects_root_volume() {
-        let result = ScalewayBackend::validate_cache_volume_id(" vol-1 ", "vol-1", &handle());
-        assert!(
-            matches!(
-                result,
-                Err(ScalewayBackendError::VolumeAttachmentFailed { .. })
-            ),
-            "expected VolumeAttachmentFailed for identical ids, got {result:?}"
+    #[rstest]
+    // Identical IDs after trimming mean the root volume is being offered
+    // as the cache volume, which must be refused.
+    #[case(" vol-1 ", "vol-1", true)]
+    #[case("vol-1", "vol-2", false)]
+    fn validate_cache_volume_id_rejects_only_the_root_volume(
+        #[case] cache_volume_id: &str,
+        #[case] root_volume_id: &str,
+        #[case] expect_rejection: bool,
+    ) {
+        let result =
+            ScalewayBackend::validate_cache_volume_id(cache_volume_id, root_volume_id, &handle());
+        let rejected = matches!(
+            result,
+            Err(ScalewayBackendError::VolumeAttachmentFailed { .. })
         );
-    }
-
-    #[test]
-    fn validate_cache_volume_id_accepts_distinct_volume() {
-        let result = ScalewayBackend::validate_cache_volume_id("vol-1", "vol-2", &handle());
-        assert!(result.is_ok(), "expected Ok for distinct ids: {result:?}");
+        assert_eq!(
+            rejected, expect_rejection,
+            "cache={cache_volume_id:?} root={root_volume_id:?}: {result:?}"
+        );
     }
 
     #[test]

--- a/src/scaleway/mod.rs
+++ b/src/scaleway/mod.rs
@@ -229,6 +229,9 @@ impl VolumeBackend for ScalewayBackend {
 mod tests {
     //! Unit tests for Scaleway backend tagging, error classification, and
     //! volume validation.
+    //!
+    //! Kills the error-classification and cache-volume validation survivors
+    //! tracked in #57.
     use rstest::rstest;
 
     use super::ScalewayBackend;

--- a/src/sync/tests/remote.rs
+++ b/src/sync/tests/remote.rs
@@ -27,7 +27,7 @@ fn run_remote_with_fake_output(
 ) -> Result<(ScriptedRunner, RemoteCommandOutput), SyncError> {
     let runner = ScriptedRunner::new();
     script(&runner);
-    let syncer = Syncer::new(cfg, runner.clone()).expect("config should validate");
+    let syncer = Syncer::new(cfg, runner.clone())?;
     let output = syncer.run_remote(networking, "echo ok")?;
     Ok((runner, output))
 }

--- a/src/sync/tests/ssh.rs
+++ b/src/sync/tests/ssh.rs
@@ -70,6 +70,7 @@ fn rsync_remote_shell_includes_identity_flag(base_config: SyncConfig) {
     );
 }
 
+// Kills the `common_ssh_options` survivors tracked in #59.
 fn ssh_option_strings(cfg: SyncConfig) -> Vec<String> {
     let runner = ScriptedRunner::new();
     let syncer = Syncer::new(cfg, runner).expect("config should validate");

--- a/src/sync/tests/ssh.rs
+++ b/src/sync/tests/ssh.rs
@@ -69,3 +69,66 @@ fn rsync_remote_shell_includes_identity_flag(base_config: SyncConfig) {
         "remote shell should include key path: {rsh_arg}"
     );
 }
+
+fn ssh_option_strings(cfg: SyncConfig) -> Vec<String> {
+    let runner = ScriptedRunner::new();
+    let syncer = Syncer::new(cfg, runner).expect("config should validate");
+    syncer
+        .common_ssh_options(22)
+        .iter()
+        .map(|a| a.to_string_lossy().into_owned())
+        .collect()
+}
+
+#[rstest]
+#[case(false, true)]
+#[case(true, false)]
+fn common_ssh_options_toggles_strict_host_key_checking(
+    base_config: SyncConfig,
+    #[case] strict: bool,
+    #[case] expect_flag: bool,
+) {
+    let cfg = SyncConfig {
+        ssh_strict_host_key_checking: strict,
+        ..base_config
+    };
+    let args = ssh_option_strings(cfg);
+    assert_eq!(
+        args.contains(&String::from("StrictHostKeyChecking=no")),
+        expect_flag,
+        "strict={strict} produced unexpected options: {args:?}"
+    );
+}
+
+#[rstest]
+fn common_ssh_options_includes_known_hosts_file_when_set(base_config: SyncConfig) {
+    let cfg = SyncConfig {
+        ssh_known_hosts_file: String::from("/dev/null"),
+        ..base_config
+    };
+    let args = ssh_option_strings(cfg);
+    assert!(
+        args.contains(&String::from("UserKnownHostsFile=/dev/null")),
+        "expected known-hosts option: {args:?}"
+    );
+}
+
+#[rstest]
+#[case("")]
+#[case("   ")]
+fn common_ssh_options_omits_blank_known_hosts_file(
+    base_config: SyncConfig,
+    #[case] known_hosts: &str,
+) {
+    let cfg = SyncConfig {
+        ssh_known_hosts_file: String::from(known_hosts),
+        ..base_config
+    };
+    let args = ssh_option_strings(cfg);
+    assert!(
+        !args
+            .iter()
+            .any(|arg| arg.starts_with("UserKnownHostsFile=")),
+        "blank known-hosts path must not emit an option: {args:?}"
+    );
+}

--- a/src/sync/tests/ssh.rs
+++ b/src/sync/tests/ssh.rs
@@ -70,15 +70,19 @@ fn rsync_remote_shell_includes_identity_flag(base_config: SyncConfig) {
     );
 }
 
-// Kills the `common_ssh_options` survivors tracked in #59.
-fn ssh_option_strings(cfg: SyncConfig) -> Vec<String> {
+/// Builds the SSH option strings a `Syncer` emits for the given configuration.
+///
+/// Kills the `common_ssh_options` survivors tracked in #59. Configuration
+/// validation is fallible, so the arrangement propagates rather than panics;
+/// only the test body unwraps.
+fn ssh_option_strings(cfg: SyncConfig) -> Result<Vec<String>, SyncError> {
     let runner = ScriptedRunner::new();
-    let syncer = Syncer::new(cfg, runner).expect("config should validate");
-    syncer
+    let syncer = Syncer::new(cfg, runner)?;
+    Ok(syncer
         .common_ssh_options(22)
         .iter()
         .map(|a| a.to_string_lossy().into_owned())
-        .collect()
+        .collect())
 }
 
 #[rstest]
@@ -93,7 +97,7 @@ fn common_ssh_options_toggles_strict_host_key_checking(
         ssh_strict_host_key_checking: strict,
         ..base_config
     };
-    let args = ssh_option_strings(cfg);
+    let args = ssh_option_strings(cfg).expect("config should validate");
     assert_eq!(
         args.contains(&String::from("StrictHostKeyChecking=no")),
         expect_flag,
@@ -107,7 +111,7 @@ fn common_ssh_options_includes_known_hosts_file_when_set(base_config: SyncConfig
         ssh_known_hosts_file: String::from("/dev/null"),
         ..base_config
     };
-    let args = ssh_option_strings(cfg);
+    let args = ssh_option_strings(cfg).expect("config should validate");
     assert!(
         args.contains(&String::from("UserKnownHostsFile=/dev/null")),
         "expected known-hosts option: {args:?}"
@@ -125,7 +129,7 @@ fn common_ssh_options_omits_blank_known_hosts_file(
         ssh_known_hosts_file: String::from(known_hosts),
         ..base_config
     };
-    let args = ssh_option_strings(cfg);
+    let args = ssh_option_strings(cfg).expect("config should validate");
     assert!(
         !args
             .iter()

--- a/src/sync/tests/streaming.rs
+++ b/src/sync/tests/streaming.rs
@@ -5,31 +5,33 @@ use rstest::rstest;
 use std::ffi::OsString;
 use std::fmt::Write as _;
 
-/// Helper to run a shell script via `StreamingCommandRunner` and assert expected output.
-fn assert_streaming_runner_output(
-    script: &str,
-    expected_code: Option<i32>,
-    expected_stdout: &str,
-    expected_stderr: &str,
-) {
-    let runner = StreamingCommandRunner;
-    let output = runner
-        .run("sh", &[OsString::from("-c"), OsString::from(script)])
-        .expect("command should execute successfully");
+/// Runs a shell script via `StreamingCommandRunner` and asserts its exit code,
+/// stdout, and stderr.
+///
+/// This is a macro rather than a helper function so that failures report the
+/// line of the calling test, and so the fallible `run` call stays inside a
+/// recognized test body.
+macro_rules! assert_streaming_runner_output {
+    ($script:expr, $expected_code:expr, $expected_stdout:expr, $expected_stderr:expr $(,)?) => {{
+        let runner = StreamingCommandRunner;
+        let output = runner
+            .run("sh", &[OsString::from("-c"), OsString::from($script)])
+            .expect("command should execute successfully");
 
-    assert_eq!(output.code, expected_code);
-    assert_eq!(output.stdout, expected_stdout);
-    assert_eq!(output.stderr, expected_stderr);
+        assert_eq!(output.code, $expected_code);
+        assert_eq!(output.stdout, $expected_stdout);
+        assert_eq!(output.stderr, $expected_stderr);
+    }};
 }
 
 #[rstest]
 fn streaming_runner_captures_output() {
-    assert_streaming_runner_output("printf out && printf err 1>&2", Some(0), "out", "err");
+    assert_streaming_runner_output!("printf out && printf err 1>&2", Some(0), "out", "err");
 }
 
 #[rstest]
 fn streaming_runner_captures_output_on_failure() {
-    assert_streaming_runner_output(
+    assert_streaming_runner_output!(
         "printf out && printf err 1>&2; exit 42",
         Some(42),
         "out",


### PR DESCRIPTION
Addresses #55, #56, #57, #58, #59.

## Summary

Kills all 32 mutation-testing survivors from the full dispatch run
([29074663742](https://github.com/leynos/mriya/actions/runs/29074663742),
dataset SHA `1004e607`): 26 real test gaps closed with new unit tests, one
subsumed predicate clause deleted (two mutants), one equivalent mutant and
three test-backdoor scaffolding functions excluded via a new
`.cargo/mutants.toml` with inline justifications. Scoped confirmation
re-runs surfaced four further missed mutants beyond the worklist; these are
also killed. Two new network-boundary mutants remain and are documented
below.

## Review walkthrough

- [`src/config_store/tests.rs`](https://github.com/leynos/mriya/blob/kill-mutation-survivors/src/config_store/tests.rs)
  (#55): the real on-disk `ConfigStore::current_volume_id` path was only
  ever observed through a test double. New tests exercise the production
  implementation against a temporary directory: a write/read round trip
  asserting the exact ID, a missing-config read asserting `Ok(None)`, and a
  probe through a regular file asserting the `NotADirectory` failure
  surfaces as an `Io` error rather than "does not exist".
- [`src/init/tests.rs`](https://github.com/leynos/mriya/blob/kill-mutation-survivors/src/init/tests.rs)
  and
  [`src/init/helpers.rs`](https://github.com/leynos/mriya/blob/kill-mutation-survivors/src/init/helpers.rs)
  (#56): unit tests for `InitConfig::validate` (zero rejected, non-zero
  accepted), a four-case table test covering every `format_failure_message`
  arm, plus `FormatFailure` Display and `append_teardown_note` coverage.
  The tautological `BYTES_PER_GB` test now asserts the literal
  `2_147_483_648` instead of `2 * BYTES_PER_GB`, which mutated together
  with the code under test.
- [`src/scaleway/mod.rs`](https://github.com/leynos/mriya/blob/kill-mutation-survivors/src/scaleway/mod.rs)
  (#57): direct unit tests for `is_instance_type_error` (four
  classification cases) and `validate_cache_volume_id` (identical trimmed
  IDs rejected, distinct IDs accepted). The dead third clause of
  `is_instance_type_error` — subsumed by the first clause, so no mutation
  inside it could ever change the result — is deleted (category 3, two
  mutants).
- [`src/scaleway/lifecycle/wait.rs`](https://github.com/leynos/mriya/blob/kill-mutation-survivors/src/scaleway/lifecycle/wait.rs)
  (#58): the fetch seam. The polling loop bodies move verbatim into
  generic `poll_for_public_ip` / `poll_until_gone` helpers parameterized
  over an instance-fetch closure (timing and port grouped in a copyable
  `PollSettings`); `wait_for_public_ip` and `wait_until_gone` become thin
  delegating wrappers passing `|| self.fetch_instance(handle)`. Behaviour
  is unchanged.
- [`src/scaleway/lifecycle/tests/wait.rs`](https://github.com/leynos/mriya/blob/kill-mutation-survivors/src/scaleway/lifecycle/tests/wait.rs)
  (#58): the `FakeBackend` that duplicated the polling algorithm is
  deleted; the tests drive the production loops with scripted snapshot
  sequences, plus two new cases: a happy path (`[starting, running + IP]`
  succeeds) and an already-gone teardown (`Ok(())`).
- [`src/scaleway/lifecycle/tests/mod.rs`](https://github.com/leynos/mriya/blob/kill-mutation-survivors/src/scaleway/lifecycle/tests/mod.rs)
  (#58): `power_on_if_needed` with a stopped snapshot offering only a
  `reboot` action must report `PowerOnNotAllowed`; the surviving `==`→`!=`
  mutant instead attempts the power-on API call and surfaces a provider
  error.
- [`src/sync/tests/ssh.rs`](https://github.com/leynos/mriya/blob/kill-mutation-survivors/src/sync/tests/ssh.rs)
  (#59): `common_ssh_options` assertions for both toggles —
  `StrictHostKeyChecking=no` present when checking is disabled and absent
  when enabled, and `UserKnownHostsFile=<path>` present for a configured
  path and absent for blank or whitespace-only values.
- [`.cargo/mutants.toml`](https://github.com/leynos/mriya/blob/kill-mutation-survivors/.cargo/mutants.toml):
  excludes the `cfg(any(test, feature = "test-backdoors"))` scaffolding in
  `src/main.rs` (`enable_fake_modes`, `fake_run_from_env`,
  `fake_dump_request`, `prefail_from_env`) — mirroring the caller
  workflow's existing `src/test_support.rs` exclude-glob — and the
  equivalent `InstanceRequest::builder` → `Default::default()` mutant
  (`InstanceRequestBuilder::new()` is defined as `Self::default()`, so the
  mutant is behaviourally identical). Justifications are inline in the
  file.

## Survivor counts (before → after)

Scoped re-runs: `cargo mutants --file <file> -- --all-features` at this
branch's head.

| File | Worklist survivors | After | Scoped re-run result |
|---|---|---|---|
| `src/config_store/mod.rs` | 4 | 0 | 18 caught, 6 unviable |
| `src/init/mod.rs` | 6 | 0 | 18 caught, 6 unviable |
| `src/init/helpers.rs` | 4 | 0 | 14 caught |
| `src/scaleway/mod.rs` | 6 | 0 | 15 caught, 7 unviable |
| `src/scaleway/lifecycle/wait.rs` | 5 | 0 (2 new, see Notes) | 9 caught, 6 unviable, 2 missed |
| `src/scaleway/lifecycle/create.rs` | 1 | 0 | 3 caught, 2 unviable |
| `src/sync/mod.rs` | 2 | 0 | 14 caught, 7 unviable |
| `src/main.rs` | 3 | excluded (scaffolding) | patterns verified via `--list` |
| `src/backend.rs` | 1 | excluded (equivalent) | pattern verified via `--list` |
| **Total** | **32** | **0 of 32** | |

Four additional missed mutants beyond the worklist were surfaced by the
scoped re-runs and killed in the same PR: the `path_exists` `NotFound`
match guard (config store), `FormatFailure::fmt`, and both
`append_teardown_note` replacements (init).

## Red–green evidence

Each module's new tests were verified by hand-applying a representative
surviving mutant, observing the failure, reverting, and observing the
pass. One transcript per module:

**config_store** (`mod.rs:139` delete `!`):

```text
=== RED config_store: mod.rs:139 delete ! ===
test config_store::tests::current_volume_id_returns_none_when_config_missing ... FAILED
test config_store::tests::current_volume_id_round_trips_written_id ... FAILED
=== GREEN config_store restored ===
test result: ok. 2 passed; 0 failed
```

**init** (`helpers.rs:3` replace `*` with `+` in `BYTES_PER_GB`):

```text
=== RED init: helpers.rs:3 replace * with + in BYTES_PER_GB ===
test init::helpers::tests::volume_size_bytes_converts_gb ... FAILED
assertion `left == right` failed
  left: 2099200
 right: 2147483648
=== GREEN init restored ===
test result: ok. 13 passed; 0 failed
```

**scaleway classification** (`mod.rs:42` replace `||` with `&&`):

```text
=== RED scaleway/mod.rs:42 replace || with && ===
test scaleway::tests::is_instance_type_error_classifies::case_2 ... FAILED
test scaleway::tests::is_instance_type_error_classifies::case_1 ... FAILED
=== GREEN scaleway/mod.rs restored ===
test result: ok. 4 passed; 0 failed
```

**lifecycle wait** (`wait.rs` replace `!=` with `==` in the state check):

```text
=== RED wait.rs: replace != with == (state check) ===
test ...wait::wait_for_public_ip_returns_missing_ip ... FAILED
test ...wait::wait_for_public_ip_returns_networking_once_running ... FAILED
expected networking, got instance id missing public IPv4 address
=== GREEN wait.rs restored ===
test result: ok. 6 passed; 0 failed
```

**lifecycle create** (`create.rs:50` replace `==` with `!=`):

```text
=== RED create.rs:50 replace == with != (poweron action) ===
test ...power_on_if_needed_ignores_non_poweron_actions ... FAILED
expected PowerOnNotAllowed error, got Err(Provider { message: "Request: error decoding response body: ..." })
=== GREEN create.rs restored ===
test result: ok. 3 passed; 0 failed
```

**sync** (`mod.rs:241` delete `!`):

```text
=== RED sync/mod.rs:241 delete ! (strict host key checking) ===
test sync::tests::ssh::common_ssh_options_toggles_strict_host_key_checking::case_1 ... FAILED
test sync::tests::ssh::common_ssh_options_toggles_strict_host_key_checking::case_2 ... FAILED
=== GREEN sync/mod.rs restored ===
test result: ok. 6 passed; 0 failed
```

## Validation

- `make check-fmt`, `make lint` (doc, clippy, Whitaker dylint), and
  `make test` (`--all-targets --all-features`, warnings denied) all pass.
- `make markdownlint` and `make test-workflow-contracts` pass.
- Scoped `cargo mutants --file` re-runs per file as tabulated above.

## Notes

- Two new missed mutants remain in `wait.rs`, both at the network
  boundary: `fetch_instance -> Ok(None)` (the function is a thin mapping
  over the live Scaleway list-instances call) and the delegation mutant
  `wait_until_gone -> Ok(())` on the thin wrapper introduced by the seam.
  Killing either would require stubbing the Scaleway HTTP API in unit
  tests; they are documented here rather than excluded so future runs
  keep reporting them honestly. In the harvested run the former appears
  to account for the single timeout (the 300-second production
  wait-timeout spun until the harness gave up).
- The `power_on_if_needed` kill is observable because the mutant path
  attempts a real API call that fails; the un-mutated test path performs
  no network I/O.

## Summary by Sourcery

Strengthen Scaleway lifecycle, init, config store, and sync SSH behaviour with new unit tests and polling helpers, and configure mutation-testing exclusions for non-production scaffolding and an equivalent builder mutant.

New Features:
- Introduce generic polling helpers for Scaleway instance readiness and teardown that can be driven by scripted fetch closures.
- Add dedicated init module tests for configuration validation, mkfs failure message formatting, and teardown-note construction.
- Add tests for config store volume ID persistence and error reporting when probing through non-directory parents.
- Add tests for Scaleway backend instance-type error classification and cache volume ID validation.
- Add tests for SSH option construction, covering strict host key checking and known-hosts file behaviour.
- Add a new lifecycle test ensuring non-poweron actions are reported as not powerable.

Enhancements:
- Refactor Scaleway wait loops to delegate to shared polling helpers, reducing duplication between production code and tests.
- Simplify lifecycle wait tests to exercise the real polling loops via scripted snapshot sequences instead of a fake backend.
- Tighten the BYTES_PER_GB test to assert the literal byte value rather than recomputing it from the constant, improving mutation sensitivity.

Build:
- Add a cargo-mutants configuration file that excludes test-backdoor scaffolding in main and an equivalent InstanceRequest builder mutant from mutation testing runs.

Documentation:
- Document the rationale for removed Scaleway error-classification clause and the behaviour of polling helpers and test-driven fetch closures.

Tests:
- Expand Scaleway lifecycle wait and teardown tests to cover successful IP acquisition, missing IP error, residual resource timeout, and SSH readiness behaviour.
- Add rstest-based coverage for Scaleway instance-type error classification and cache volume validation edge cases.
- Add rstest-based init tests for validation, mkfs failure message arms, and teardown note behaviour.
- Add config store tests covering volume ID round-trip, missing-config handling, and non-directory parent path errors.
- Add sync SSH option tests for strict host key checking toggles and known-hosts file inclusion/omission.
- Add a lifecycle power-on test that verifies non-poweron actions do not trigger API calls and are reported as not allowed.

## References

- Lody session: https://lody.ai/leynos/sessions/d222a56c-22ae-4cdf-ad18-22b9a9f502f7
