### PR TITLE
Stop pinning the mutation-cargo caller SHA in contract tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing
+
+Thank you for your interest in contributing to Mriya. Please see
+`AGENTS.md` for detailed code style, testing, and commit conventions.
+
+## Workflow pins and Dependabot
+
+Dependabot owns the upgrade of GitHub Actions and reusable workflows,
+including calls into `leynos/shared-actions`. Contract tests that assert a
+caller's exact commit SHA create a lockstep dependency: every time Dependabot
+opens a bump PR, the test fails until a human edits the pinned constant to
+match. That defeats the purpose of automated dependency updates and turns a
+routine bump into a manual chore.
+
+Contract tests may still verify the *shape* of a reusable-workflow caller.
+They must not verify the specific SHA value.
+
+- Do assert the workflow references the correct reusable workflow path.
+- Do assert the ref is pinned to a full 40-character commit SHA, not a
+  mutable branch such as `main` or `rolling`.
+- Do assert the expected `on:` triggers, least-privilege `permissions:`, and
+  the inputs the caller relies on.
+- Do not hard-code the current SHA value as an expected string. Match it with
+  a pattern instead.
+- Do not fail a test purely because Dependabot bumped the pinned SHA.
+
+```python
+import re
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+def test_uses_pinned_full_sha(caller_step):
+    ref = caller_step["uses"].split("@")[-1]
+    assert SHA_RE.match(ref), f"expected a 40-hex commit SHA, got {ref!r}"
+```
+
+If a workflow's behaviour genuinely depends on a feature only present from a
+particular commit onwards, express that as a comment or a changelog note, not
+as a test assertion on the SHA string.

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -3,16 +3,20 @@
 The executable logic lives in the ``leynos/shared-actions`` reusable
 workflow, which carries its own unit and integration tests; mriya's
 caller is declarative configuration. These tests parse the caller with
-PyYAML and pin the contract it must uphold, so drift (repointing the pin
-at a branch, widening permissions, or losing the exclude and feature
+PyYAML and assert that it references the correct reusable workflow at a
+commit SHA, and that the other structural guarantees (permissions,
+triggers, the exclude and feature configuration) hold. Dependabot owns
+the pinned SHA value itself, so drift there (repointing the pin at a
+branch, widening permissions, or losing the exclude and feature
 configuration) fails CI on the pull request rather than surfacing in a
-scheduled or manual run.
+scheduled or manual run — but a routine Dependabot SHA bump does not.
 
 Run via ``make test-workflow-contracts``.
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import yaml
@@ -21,12 +25,10 @@ WORKFLOW_PATH = (
     Path(__file__).resolve().parents[2] / ".github" / "workflows" / "mutation-testing.yml"
 )
 
-#: The leynos/shared-actions commit the caller pins. Bump the workflow
-#: and this constant together.
-PINNED_SHA = "927edd45ae77be4251a8a18ca9eb5613a2e32cbd"
-
-EXPECTED_USES = (
-    "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA
+#: Matches the mutation-cargo caller pinned to a full 40-hex commit SHA.
+#: The SHA value itself is intentionally unconstrained: Dependabot owns it.
+USES_RE = re.compile(
+    r"^leynos/shared-actions/\.github/workflows/mutation-cargo\.yml@[0-9a-f]{40}$"
 )
 
 #: The exact caller configuration: exclude the unconditionally compiled
@@ -60,25 +62,18 @@ def _mutation_job(workflow: dict[str, object]) -> dict[str, object]:
     return jobs["mutation"]
 
 
-def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
-    """The job must call the shared workflow at the exact documented SHA."""
+def test_uses_reference_is_pinned_to_a_commit_sha() -> None:
+    """The job must call mutation-cargo.yml pinned to a 40-hex commit SHA.
+
+    The specific SHA value is not asserted: Dependabot owns bumping it,
+    and pinning the value here would fail every routine bump PR.
+    """
     uses = _mutation_job(_load()).get("uses")
     assert uses is not None, "jobs.mutation.uses is missing"
-    path, _, ref = uses.partition("@")
-    assert path == "leynos/shared-actions/.github/workflows/mutation-cargo.yml", (
-        f"jobs.mutation.uses must reference mutation-cargo.yml, got {path!r}"
-    )
-    assert len(ref) == 40, (
-        f"jobs.mutation.uses must pin a full 40-character commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert all(c in "0123456789abcdef" for c in ref), (
-        f"jobs.mutation.uses must pin a lowercase hex commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert uses == EXPECTED_USES, (
-        f"jobs.mutation.uses pins {ref!r}; this test documents {PINNED_SHA!r} — "
-        "bump the workflow and this test together"
+    assert USES_RE.match(uses), (
+        f"jobs.mutation.uses must reference mutation-cargo.yml pinned to a "
+        f"full 40-character lowercase hex commit SHA (not a branch or tag), "
+        f"got {uses!r}"
     )
 
 


### PR DESCRIPTION
## Summary

- Replace the mutation-testing workflow contract test's exact-SHA
  assertion with a shape assertion: it still confirms the caller
  references `mutation-cargo.yml` pinned to a full 40-hex commit SHA
  (not a mutable branch or tag), but no longer pins the specific value.
- Remove the `PINNED_SHA` constant and its "bump the workflow and this
  test together" comment; update the module docstring to describe the
  new contract.
- Add `CONTRIBUTING.md` documenting the workflow-pin policy: Dependabot
  owns the SHA value, contract tests own the shape.

## Why

The previous test asserted `jobs.mutation.uses ==
"leynos/shared-actions/.github/workflows/mutation-cargo.yml@<exact sha>"`.
Every Dependabot bump PR for that reusable workflow therefore failed CI
until a human hand-edited the constant to match, turning a routine
automated update into a manual chore. This hands SHA ownership fully to
Dependabot while keeping every other structural guard in place
(permissions, triggers, concurrency, the `with:` block).

`.github/dependabot.yml` already has a `github-actions` ecosystem entry
with `directory: "/"`, so no changes were needed there.

## Review walkthrough

- `tests/workflow_contracts/mutation_testing_test.py`: swap the
  `PINNED_SHA` constant and equality assertion for a `USES_RE` regex
  (`^leynos/shared-actions/\.github/workflows/mutation-cargo\.yml@[0-9a-f]{40}$`)
  and a `match()` assertion. All other tests in the file (permissions,
  workflow-level permissions, concurrency, triggers, `with:` block) are
  unchanged.
- `CONTRIBUTING.md`: new file (none previously existed) documenting the
  workflow-pin policy for future contributors.

## Validation

- `make test-workflow-contracts` — 6 passed, including the updated
  shape assertion against the current pinned SHA
  (`927edd45ae77be4251a8a18ca9eb5613a2e32cbd`).
- Reasoned about the regex: it is anchored (`^...$`), requires the exact
  reusable-workflow path, and requires exactly 40 lowercase hex
  characters after `@` — so it matches the current SHA and would equally
  match any other valid 40-hex SHA a Dependabot bump might introduce,
  while still rejecting a branch or tag ref.
- `make markdownlint` — 0 errors.
