### PR TITLE
Replace panic closures in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 target/
 **/*.rs.bk
 __pycache__/
+*.py[cod]
+*$py.class
 .memdb/

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -115,7 +115,7 @@ async fn dispatch_uses_hook_result() {
 #[test]
 fn parse_override_trims_and_accepts_nonempty_values() {
     let parsed = parse_override("--instance-type", "  DEV1-M  ")
-        .unwrap_or_else(|err| panic!("expected override to parse: {err}"));
+        .expect("non-empty instance type override should parse");
     assert_eq!(parsed, "DEV1-M");
 }
 
@@ -153,8 +153,7 @@ fn apply_instance_overrides_updates_request() {
         command: vec![String::from("echo"), String::from("ok")],
     };
 
-    apply_instance_overrides(&mut request, &args)
-        .unwrap_or_else(|err| panic!("expected overrides to apply: {err}"));
+    apply_instance_overrides(&mut request, &args).expect("valid instance overrides should apply");
 
     assert_eq!(request.instance_type, "DEV1-M");
     assert_eq!(request.image_label, "ubuntu-22-04");

--- a/src/scaleway/lifecycle/tests/wait.rs
+++ b/src/scaleway/lifecycle/tests/wait.rs
@@ -115,10 +115,10 @@ async fn wait_for_public_ip_returns_missing_ip() {
 async fn wait_for_ssh_ready_succeeds_when_port_listens() {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
-        .unwrap_or_else(|err| panic!("bind listener: {err}"));
+        .expect("test TCP listener should bind to a loopback port");
     let addr = listener
         .local_addr()
-        .unwrap_or_else(|err| panic!("listener addr: {err}"));
+        .expect("test TCP listener should expose its local address");
     tokio::spawn(async move { if let Ok((_stream, _addr)) = listener.accept().await {} });
 
     let backend = ScalewayBackend {
@@ -141,17 +141,17 @@ async fn wait_for_ssh_ready_succeeds_when_port_listens() {
     backend
         .wait_for_ssh_ready(&handle, &networking)
         .await
-        .unwrap_or_else(|err| panic!("ssh should be reachable: {err}"));
+        .expect("SSH readiness check should succeed while the test port listens");
 }
 
 #[tokio::test]
 async fn wait_for_ssh_ready_times_out_when_port_closed() {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
-        .unwrap_or_else(|err| panic!("bind listener: {err}"));
+        .expect("test TCP listener should bind before simulating a closed port");
     let addr = listener
         .local_addr()
-        .unwrap_or_else(|err| panic!("listener addr: {err}"));
+        .expect("test TCP listener should expose its address before closing");
     drop(listener);
 
     let backend = ScalewayBackend {
@@ -168,8 +168,7 @@ async fn wait_for_ssh_ready_times_out_when_port_closed() {
         zone: String::from("zone"),
     };
     let networking = InstanceNetworking {
-        public_ip: IpAddr::from_str("127.0.0.1")
-            .unwrap_or_else(|err| panic!("loopback ip parse: {err}")),
+        public_ip: IpAddr::from_str("127.0.0.1").expect("loopback address literal should parse"),
         ssh_port: addr.port(),
     };
     let err = backend

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -143,10 +143,10 @@ fn config_as_request_produces_valid_request() {
     let cfg = valid_config();
     let request = cfg
         .as_request()
-        .unwrap_or_else(|err| panic!("valid config yields request: {err}"));
+        .expect("valid configuration should produce an instance request");
     request
         .validate()
-        .unwrap_or_else(|err| panic!("request from config validates: {err}"));
+        .expect("request produced from valid configuration should validate");
     assert_eq!(request.image_label, cfg.default_image);
     assert_eq!(request.instance_type, cfg.default_instance_type);
     assert_eq!(request.zone, cfg.default_zone);
@@ -194,7 +194,7 @@ fn config_rejects_empty_cloud_init_inline() {
 #[test]
 fn config_reads_cloud_init_user_data_from_file() {
     let (_tmp, path_str) = write_temp_cloud_init_file("user-data.txt", "file-user-data")
-        .unwrap_or_else(|err| panic!("create cloud-init file: {err}"));
+        .expect("cloud-init fixture file should be created");
 
     let cfg = ScalewayConfig {
         cloud_init_user_data_file: Some(path_str),
@@ -203,7 +203,7 @@ fn config_reads_cloud_init_user_data_from_file() {
 
     let request = cfg
         .as_request()
-        .unwrap_or_else(|err| panic!("as_request should succeed: {err}"));
+        .expect("configuration with a cloud-init fixture should produce a request");
     assert_eq!(
         request.cloud_init_user_data,
         Some(String::from("file-user-data"))
@@ -212,11 +212,12 @@ fn config_reads_cloud_init_user_data_from_file() {
 
 #[test]
 fn config_errors_when_cloud_init_user_data_file_missing() {
-    let tmp = TempDir::new().unwrap_or_else(|err| panic!("tempdir: {err}"));
+    let tmp = TempDir::new()
+        .expect("temporary directory for the missing cloud-init fixture should be created");
     let missing_path = tmp.path().join("does-not-exist.txt");
     let missing_path_str = missing_path
         .to_str()
-        .unwrap_or_else(|| panic!("temp path should be utf8: {}", missing_path.display()))
+        .expect("temporary missing-file path should be valid UTF-8")
         .to_owned();
 
     let cfg = ScalewayConfig {
@@ -238,7 +239,7 @@ fn config_errors_when_cloud_init_user_data_file_missing() {
 #[test]
 fn config_errors_when_cloud_init_user_data_file_is_empty() {
     let (_tmp, path_str) = write_temp_cloud_init_file("user-data-empty.txt", "   \n\t  ")
-        .unwrap_or_else(|err| panic!("create cloud-init file: {err}"));
+        .expect("empty cloud-init fixture file should be created");
 
     let cfg = ScalewayConfig {
         cloud_init_user_data_file: Some(path_str),
@@ -261,18 +262,18 @@ fn config_errors_when_cloud_init_user_data_file_is_empty() {
 
 #[tokio::test]
 async fn config_expands_tilde_for_cloud_init_user_data_file() {
-    let tmp = TempDir::new().unwrap_or_else(|err| panic!("tempdir: {err}"));
+    let tmp = TempDir::new().expect("temporary home directory should be created");
     let home = tmp.path().to_string_lossy().to_string();
     let _guard = mriya::test_support::EnvGuard::set_vars(&[("HOME", home.as_str())]).await;
 
     let tmp_root = Utf8PathBuf::from_path_buf(tmp.path().to_path_buf())
-        .unwrap_or_else(|path| panic!("temp home dir should be utf8: {}", path.display()));
+        .expect("temporary home directory path should be valid UTF-8");
     let fs = Dir::open_ambient_dir(&tmp_root, ambient_authority())
-        .unwrap_or_else(|err| panic!("open temp home dir: {err}"));
+        .expect("temporary home directory should open");
     fs.create_dir_all("cloud-init")
-        .unwrap_or_else(|err| panic!("create cloud-init dir: {err}"));
+        .expect("cloud-init fixture directory should be created");
     fs.write("cloud-init/user-data.txt", "tilde-user-data")
-        .unwrap_or_else(|err| panic!("write tilde user-data file: {err}"));
+        .expect("tilde-expanded cloud-init fixture should be written");
 
     let cfg = ScalewayConfig {
         cloud_init_user_data_file: Some(String::from("~/cloud-init/user-data.txt")),
@@ -281,7 +282,7 @@ async fn config_expands_tilde_for_cloud_init_user_data_file() {
 
     let request = cfg
         .as_request()
-        .unwrap_or_else(|err| panic!("as_request should succeed: {err}"));
+        .expect("configuration with a tilde-expanded cloud-init file should produce a request");
 
     assert_eq!(
         request.cloud_init_user_data,


### PR DESCRIPTION
## Summary

- replace test-only `unwrap_or_else(... panic!)` closures with descriptive
  test-boundary expectations
- preserve underlying configuration, lifecycle and command errors
- complete the canonical Python compilation-artefact ignore policy
- clear the strict Whitaker findings blocking the spelling rollout

## Validation

- focused configuration, lifecycle-wait and command tests under warnings
- `make check-fmt`
- `make lint` (Rustdoc, Clippy and Whitaker)
- `make typecheck`
- `make test` (151 passed)
- workflow contracts (6 passed)
- `make markdownlint`
- `make nixie` with Merman
- Mbake and Actionlint across six workflows
- canonical Python compilation-artefact audit

Credentialed and destructive live Scaleway gates were not run. The repository
does not yet have a spelling target or generated `typos.toml`; those are part
of the separately prepared rollout.

## Hosted status

Build/test, the complete release-smoke matrix and CodeScene coverage are Green
on exact head `3c54a1302c024f49a39c91d130ccc59eb8b87bc1`. A final thread-aware audit
found zero review threads and no maintained actionable request. Sourcery and
CodeRabbit reported only review-quota notices; a substantive exact-head Scribe
audit found no defect in the four changed files.

## References

- Branch comparison: https://github.com/leynos/mriya/compare/main...fix/whitaker-test-panics
- Exact repair head: https://github.com/leynos/mriya/commit/3c54a1302c024f49a39c91d130ccc59eb8b87bc1
- Successful main coverage upload: https://github.com/leynos/mriya/actions/runs/29351549052

No existing issue or roadmap item was found for this narrow lint-debt repair.
