### PR TITLE
Wire the CodeScene mode: check coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,13 +63,14 @@ jobs:
           format: lcov
           use-cargo-nextest: 'false'
           with-ratchet: 'true'
-      # The `mode: check` step is deliberately not wired in yet: CodeScene
-      # project 74420 has no coverage-gates configuration, so
-      # `cs-coverage check` fails every run with "HTTP call succeeded,
-      # but the received project-config isn't valid. Lacks the gates
-      # configuration." — a CodeScene-side per-project setting, not a CI
-      # defect (ddlint and chutoro's projects hit the byte-identical
-      # error). Add the check step in a fast-follow PR once
-      # coverage-main.yml has uploaded to main at least once and the
-      # gate is confirmed to resolve, or once CodeScene confirms the
-      # project's coverage gate is enabled.
+      - name: Check coverage against CodeScene gates
+        env:
+          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+        if: env.CS_ACCESS_TOKEN != '' && github.event_name == 'pull_request'
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@3c1fa01bcf4c26dac79975c18b74c01d577dcf95
+        with:
+          format: lcov
+          mode: check
+          project-url: https://api.codescene.io/v2/projects/74420
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}


### PR DESCRIPTION
## Summary

- CodeScene project 74420 now returns a populated coverage-gates
  configuration, so `cs-coverage check` should succeed rather than
  erroring with "Lacks the gates configuration".
- Replace the deferred-gate comment in `.github/workflows/ci.yml`
  with the real guarded `mode: check` step, in the `build-test` job
  only, after `generate-coverage`.

## Review walkthrough

- [`.github/workflows/ci.yml`](https://github.com/leynos/mriya/blob/codescene-mode-check/.github/workflows/ci.yml):
  adds a `Check coverage against CodeScene gates` step guarded on
  `CS_ACCESS_TOKEN` being set and the event being `pull_request`,
  using `format: lcov` and `project-url:
  https://api.codescene.io/v2/projects/74420`. The
  `upload-codescene-coverage` pin
  (`3c1fa01bcf4c26dac79975c18b74c01d577dcf95`) matches the one already
  used by `coverage-main.yml`'s upload step, so Dependabot keeps a
  single ownership trail for that action. `coverage-main.yml` is
  untouched (`mode: upload` stays on push-to-main only).

## Validation

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`
- [x] `make test-workflow-contracts` (6 passed; no contract asserts
      the coverage step shape)
- [ ] Confirm on this PR's own head that the `Check coverage against
      CodeScene gates` step executes (not skipped) and succeeds, and
      that the `CodeScene Code Coverage` check completes.
