### PR TITLE
Bump whitaker-installer to 0.2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       BUILD_PROFILE: debug
-      WHITAKER_INSTALLER_VERSION: '0.2.5'
+      WHITAKER_INSTALLER_VERSION: '0.2.6'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:


### PR DESCRIPTION
The whitaker Dylint suite's rolling release now pins toolchain `nightly-2026-05-28`, which requires `cargo-dylint` 6.0.1. Whitaker installer 0.2.5 provisions `cargo-dylint` 4.1.0, whose driver cannot compile on that nightly, so the repository's CI lint step has been failing. Whitaker installer 0.2.6 fixes this by provisioning `cargo-dylint` 6.0.1, and its prebuilt dependency binaries are now published.

This change bumps the pinned `WHITAKER_INSTALLER_VERSION` from `0.2.5` to `0.2.6` in the CI workflow.

## Changed files

- [`.github/workflows/ci.yml`](https://github.com/leynos/mriya/blob/bump-whitaker-installer-0.2.6/.github/workflows/ci.yml)
