### PR TITLE
Document mutation-testing workflow contract tests

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -22,3 +22,58 @@ the Makefile's `TYPING_EXTENSIONS_VERSION` because the pinned `cmd-mox` revision
 imports `typing_extensions.Self` without declaring that compatibility
 dependency. This test-only package does not belong in the helper's runtime
 metadata or the project dependency lock.
+
+## Mutation-testing workflow contract tests
+
+This repository runs scheduled, informational mutation testing through a thin
+caller workflow, [`.github/workflows/mutation-testing.yml`][mutation-workflow],
+which delegates to the shared reusable workflow
+`leynos/shared-actions/.github/workflows/mutation-cargo.yml`. The heavy
+lifting — running `cargo-mutants`, sharding, and summarizing survivors —
+lives in `shared-actions`; this repository carries only declarative
+configuration. The run is **informational only**: it never gates a pull
+request. Survivors are reported through the job summary and downloadable
+artefacts so they can be triaged into tests, not enforced as a blocking
+check.
+
+The workflow runs in two modes. A **daily schedule** fires a change-scoped
+run that mutates only the source files touched within the detection window,
+so quiet days are cheap no-ops. A **manual dispatch** (the Actions "Run
+workflow" control) mutates the whole crate; select a branch in that control
+to exercise a feature branch.
+
+The caller passes two configuration inputs, each carrying intent:
+
+- `exclude-globs` — `src/test_support.rs`, test scaffolding compiled into
+  the library unconditionally (unlike the `#[cfg(test)]`-gated
+  `test_helpers` and `tests` modules, which `cargo-mutants` skips already),
+  whose surviving mutants would otherwise be noise in the survivors table.
+- `extra-args` — `--all-features`, matching the `make test` CI baseline so
+  the `test-backdoors`-gated tests run against mutants rather than being
+  silently skipped.
+
+The `uses:` reference pins the shared workflow to a full 40-character commit
+SHA rather than a branch or tag, so a force-push upstream cannot silently
+change what runs here. The contract test asserts only that the pin is a
+full commit SHA, not a particular value, so Dependabot bumps it
+automatically without any accompanying test edit.
+
+Because the caller is configuration rather than code, a contract test pins
+the shape it must uphold, failing the pull request when the caller drifts —
+repointing the pin at a branch, widening the token scope, or dropping a
+configuration input — rather than letting the breakage surface only in a
+scheduled run. Run it locally with `make test-workflow-contracts`. The test
+validates:
+
+- the `uses:` reference targets `mutation-cargo.yml` pinned to a full commit
+  SHA;
+- the `with:` block carries exactly the expected configuration (the exclude
+  and feature arguments above);
+- job permissions are least-privilege (`contents: read`, `id-token: write`)
+  and the workflow-level default token scope is empty;
+- `concurrency` serializes runs per ref without cancelling one in progress;
+  and
+- the triggers keep the daily schedule and a plain `workflow_dispatch` with
+  no legacy branch input.
+
+[mutation-workflow]: ../.github/workflows/mutation-testing.yml


### PR DESCRIPTION
## Summary

- Adds a new `## Mutation-testing workflow contract tests` section to
  `docs/developers-guide.md`, documenting the shape-only contract test at
  `tests/workflow_contracts/mutation_testing_test.py` for
  `.github/workflows/mutation-testing.yml`.
- Describes the two-mode schedule/dispatch behaviour, the caller's actual
  `with:` inputs (`exclude-globs`, `extra-args` — this caller does not set
  `paths`), the shape-only SHA-pin assertion (`USES_RE`, unconstrained
  value, so Dependabot bumps land without a test edit), and the local run
  command `make test-workflow-contracts`.
- `docs/developers-guide.md` has no table of contents/index, so no
  cross-link entry was added; this is the only section of its kind so far.
- No roadmap or execplan tracking references mutation testing or this docs
  work in `docs/roadmap.md`, so none was updated.

Permutation A (Rust, single crate) from the mutation-testing contract-docs
brief.

## Test plan

- [x] `make markdownlint` — passes (0 errors), including the spelling
      check bundled into that target (en-GB-oxendict via `typos`).
- [ ] Rust/Python test suites intentionally not run — docs-only change.