### PR TITLE
Align Dependabot coverage and add the dev-fast build fragment

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,10 @@ updates:
     cooldown:
       default-days: 7
       semver-major-days: 14
+  - package-ecosystem: rust-toolchain
+    directory: /
+    labels:
+      - dependencies
+      - rust-toolchain
+    schedule:
+      interval: weekly

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -311,3 +311,12 @@ The following tooling is available in this environment:
 
 These practices help maintain a high-quality codebase and facilitate
 collaboration.
+
+## Fast development builds
+
+`make dev-build` and `make dev-test` compile with the opt-in Cranelift
+backend and the mold linker configured in `tools/dev-fast/config.toml`.
+They require a nightly toolchain and, on Linux, a `mold` binary on the
+`PATH`. The fragment is passed explicitly with `--config`, so release,
+coverage, and verification builds are unaffected; never copy its contents
+into `.cargo/config.toml`, which Cargo applies to every build.

--- a/Makefile
+++ b/Makefile
@@ -121,3 +121,14 @@ nixie: ## Validate Mermaid diagrams
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | \
 	awk 'BEGIN {FS=":"; printf "Available targets:\n"} {printf "  %-20s %s\n", $$1, $$2}'
+
+# Opt-in accelerated debug builds (Cranelift + mold); requires a nightly
+# toolchain. See AGENTS.md and tools/dev-fast/config.toml.
+DEV_FAST_CONFIG ?= tools/dev-fast/config.toml
+
+.PHONY: dev-build dev-test
+dev-build: ## Build debug binaries with Cranelift and mold
+	cargo --config "$(DEV_FAST_CONFIG)" build
+
+dev-test: ## Run tests with Cranelift and mold
+	cargo --config "$(DEV_FAST_CONFIG)" test

--- a/tools/dev-fast/config.toml
+++ b/tools/dev-fast/config.toml
@@ -1,0 +1,30 @@
+# Canonical opt-in Cargo configuration fragment for accelerated local debug
+# builds.
+#
+# This file is deliberately kept out of `.cargo/config.toml`. Cargo
+# auto-discovers that path, so anything placed there applies to release
+# packaging, coverage, and verification builds, which must keep the
+# supported LLVM backend and platform linker. Copy this fragment to
+# `tools/dev-fast/config.toml` and pass it explicitly with
+# `cargo --config tools/dev-fast/config.toml ...` from `make dev-build` and
+# `make dev-test`.
+#
+# Repositories that set repository-wide `rustflags` in `.cargo/config.toml`
+# must restate them in the target table below: Cargo picks a single
+# rustflags source rather than merging them, and a `[target.*]` table
+# outranks the `[build]` table.
+
+[unstable]
+codegen-backend = true
+
+# Cranelift trades runtime performance for compile speed, so it applies to
+# the dev profile only. The `make dev-*` targets never build release
+# artefacts.
+[profile.dev]
+codegen-backend = "cranelift"
+
+# mold ships for Linux only, so the flag is gated behind a target `cfg`. On
+# macOS and Windows the table simply does not apply and the platform default
+# linker is used.
+[target.'cfg(target_os = "linux")']
+rustflags = ["-Clink-arg=-fuse-ld=mold"]

--- a/tools/dev-fast/config.toml
+++ b/tools/dev-fast/config.toml
@@ -1,18 +1,19 @@
 # Canonical opt-in Cargo configuration fragment for accelerated local debug
 # builds.
 #
-# This file is deliberately kept out of `.cargo/config.toml`. Cargo
-# auto-discovers that path, so anything placed there applies to release
-# packaging, coverage, and verification builds, which must keep the
-# supported LLVM backend and platform linker. Copy this fragment to
-# `tools/dev-fast/config.toml` and pass it explicitly with
-# `cargo --config tools/dev-fast/config.toml ...` from `make dev-build` and
-# `make dev-test`.
+# This configuration is deliberately kept out of `.cargo/config.toml`.
+# Cargo auto-discovers that path, so anything placed there applies to
+# release packaging, coverage, and verification builds, which must keep
+# the supported LLVM backend and platform linker. In a consuming
+# repository this fragment lives at `tools/dev-fast/config.toml` and is
+# passed explicitly with `cargo --config tools/dev-fast/config.toml ...`
+# from `make dev-build` and `make dev-test`.
 #
 # Repositories that set repository-wide `rustflags` in `.cargo/config.toml`
-# must restate them in the target table below: Cargo picks a single
-# rustflags source rather than merging them, and a `[target.*]` table
-# outranks the `[build]` table.
+# must restate them in the target table below. Cargo joins the rustflags of
+# every matching `[target.*]` entry (target-triple and `cfg` tables alike),
+# but the joined target rustflags take precedence over `[build].rustflags`
+# rather than merging with it.
 
 [unstable]
 codegen-backend = true

--- a/typos.local.toml
+++ b/typos.local.toml
@@ -9,6 +9,9 @@ stems = []
 accepted = []
 
 [words.corrections]
+# "mold" names the linker (https://github.com/rui314/mold); it is not a
+# misspelling of "mould" in that context.
+mold = "mold"
 
 [patterns]
 ignore = [

--- a/typos.local.toml
+++ b/typos.local.toml
@@ -9,12 +9,16 @@ stems = []
 accepted = []
 
 [words.corrections]
-# "mold" names the linker (https://github.com/rui314/mold); it is not a
-# misspelling of "mould" in that context.
-mold = "mold"
 
 [patterns]
 ignore = [
+  # "mold" names the linker (https://github.com/rui314/mold) in these
+  # contexts only; the mould correction stays active elsewhere.
+  "-fuse-ld=mold",
+  "mold linker",
+  "Cranelift \\+ mold",
+  "Cranelift and mold",
+  "`mold`",
   "\\bCARGO_TERM_COLOR\\b",
   "\\bAzure Architecture Center\\b",
   "\\bCenter \\| Microsoft Learn\\b",

--- a/typos.toml
+++ b/typos.toml
@@ -30,6 +30,11 @@ extend-exclude = [
 [default]
 locale = "en-gb"
 extend-ignore-re = [
+    "-fuse-ld=mold",
+    "mold linker",
+    "Cranelift \\+ mold",
+    "Cranelift and mold",
+    "`mold`",
     "(?m)^            artifact_suffix: aarch64-apple-darwin$",
     "(?m)^            artifact_suffix: linux-aarch64$",
     "(?m)^            artifact_suffix: linux-x86_64$",
@@ -1499,7 +1504,6 @@ extend-ignore-re = [
 "modularizers" = "modularizers"
 "modularizes" = "modularizes"
 "modularizing" = "modularizing"
-"mold" = "mold"
 "monetisable" = "monetizable"
 "monetisably" = "monetizably"
 "monetisation" = "monetization"

--- a/typos.toml
+++ b/typos.toml
@@ -30,11 +30,6 @@ extend-exclude = [
 [default]
 locale = "en-gb"
 extend-ignore-re = [
-    "-fuse-ld=mold",
-    "mold linker",
-    "Cranelift \\+ mold",
-    "Cranelift and mold",
-    "`mold`",
     "(?m)^            artifact_suffix: aarch64-apple-darwin$",
     "(?m)^            artifact_suffix: linux-aarch64$",
     "(?m)^            artifact_suffix: linux-x86_64$",
@@ -51,12 +46,17 @@ extend-ignore-re = [
     "(?m)^    types: \\[opened, reopened, synchronize, labeled, ready_for_review\\]$",
     "(?m)^#\\[tokio::test\\(flavor = \"current_thread\"\\)\\]$",
     "(?s)```.*?```",
+    "-fuse-ld=mold",
+    "Cranelift \\+ mold",
+    "Cranelift and mold",
     "\\bAzure Architecture Center\\b",
     "\\bCARGO_TERM_COLOR\\b",
     "\\bCenter \\| Microsoft Learn\\b",
     "\\borganisation_id\\b",
     "\\brust-analyzer\\b",
     "`[^`\\n]+`",
+    "`mold`",
+    "mold linker",
 ]
 
 [default.extend-words]

--- a/typos.toml
+++ b/typos.toml
@@ -1499,6 +1499,7 @@ extend-ignore-re = [
 "modularizers" = "modularizers"
 "modularizes" = "modularizes"
 "modularizing" = "modularizing"
+"mold" = "mold"
 "monetisable" = "monetizable"
 "monetisably" = "monetizably"
 "monetisation" = "monetization"


### PR DESCRIPTION
## Summary

This branch applies Wave 1 of the Rust estate baseline remediation
(Operation Parabellum, phase 2). It aligns
[.github/dependabot.yml](https://github.com/leynos/mriya/blob/parabellum-wave-1/.github/dependabot.yml)
with the canonical Dependabot reference: one update stanza per package
ecosystem the repository uses (`cargo`, `rust-toolchain`, `github-actions`), each stanza labelled
`dependencies` plus its channel label, and GitHub Actions updates batched
into a single pull request via a wildcard group. It also adds the opt-in dev-fast build
fragment with `dev-build` and `dev-test` Make targets, signposted in
[AGENTS.md](https://github.com/leynos/mriya/blob/parabellum-wave-1/AGENTS.md).

## Review walkthrough

- Start with
  [.github/dependabot.yml](https://github.com/leynos/mriya/blob/parabellum-wave-1/.github/dependabot.yml)
  for the ecosystem coverage and labels.
- Then review
  [tools/dev-fast/config.toml](https://github.com/leynos/mriya/blob/parabellum-wave-1/tools/dev-fast/config.toml)
  — a copy of the canonical fragment — and the `dev-build`/`dev-test`
  targets appended to the
  [Makefile](https://github.com/leynos/mriya/blob/parabellum-wave-1/Makefile).
- Finish with the signposting section appended to
  [AGENTS.md](https://github.com/leynos/mriya/blob/parabellum-wave-1/AGENTS.md).

## Validation

- Audited the amended tree with the Concordat rule packages
  `dependabot-baseline` and `rust-dev-fast-baseline`: `dependabot-baseline` compliant, `rust-dev-fast-baseline` compliant.

## Notes

- The canonical labels (including the Dependabot channel labels this
  configuration references) were created on the repository ahead of this
  pull request, so no stanza names a missing label.
- The dev-fast fragment is strictly opt-in local tooling: it is only
  applied when passed explicitly with `--config`, so continuous
  integration, release, coverage, and verification builds are untouched.
  The targets need a nightly toolchain and, on Linux, a `mold` binary on
  the `PATH`; repositories still pinned to stable gain the wiring now and
  the capability when Wave 2 moves the pin to nightly.

## Summary by Sourcery

Introduce opt-in accelerated local debug builds and align Dependabot coverage for Rust tooling.

New Features:
- Add dev-build and dev-test Make targets that use an opt-in Cargo config fragment for faster local debug builds with Cranelift and mold.

Enhancements:
- Document the fast development build workflow and its constraints in AGENTS.md for contributors.
- Add a canonical dev-fast Cargo configuration fragment under tools/dev-fast/config.toml to support accelerated debug builds without affecting CI or release builds.

CI:
- Extend .github/dependabot.yml to track rust-toolchain updates with labeled weekly checks.